### PR TITLE
実行環境をGo 1.13に変更

### DIFF
--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -1,8 +1,6 @@
-FROM golang:1.12.7-alpine3.10 as build
+FROM golang:1.13.0-alpine3.10 as build
 
 LABEL maintainer="https://github.com/nekochans"
-
-ENV GO111MODULE on
 
 WORKDIR /go/app
 
@@ -12,7 +10,8 @@ RUN set -ex && \
   apk update && \
   apk add --no-cache git && \
   go build -o portfolio-backend && \
-  go get -u github.com/oxequa/realize && \
+  go get gopkg.in/urfave/cli.v2@master && \
+  go get github.com/oxequa/realize && \
   go get -u github.com/go-delve/delve/cmd/dlv && \
   go build -o /go/bin/dlv github.com/go-delve/delve/cmd/dlv
 

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.17.2-alpine
+FROM nginx:1.17.3-alpine
 
 LABEL maintainer="https://github.com/nekochans"
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com:nekochans/portfolio-backend
 
-go 1.12
+go 1.13
 
-require github.com/go-chi/chi v4.0.2+incompatible
+require (
+	github.com/go-chi/chi v4.0.2+incompatible
+	golang.org/x/net v0.0.0-20190912160710-24e19bdeb0f2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
 github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190912160710-24e19bdeb0f2 h1:4dVFTC832rPn4pomLSz1vA+are2+dU19w1H8OngV7nc=
+golang.org/x/net v0.0.0-20190912160710-24e19bdeb0f2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/portfolio-backend/issues/11

# Doneの定義
- Goの実行環境が1.13に変更されている事

# 変更点概要

## 技術的変更点概要
- `Dockerfile` の設定を変更
- go.modの書き換え

# 補足情報
`realize` のインストール時に以下のエラーが発生した。

```
build github.com/oxequa/realize: cannot load gopkg.in/urfave/cli.v2: cannot find module providing package gopkg.in/urfave/cli.v2
```

これはGoのバージョンアップとは無関係で、realizeが依存する `gopkg.in/urfave/cli` のバージョンが2系に変更され、さらにその2系がGo Moduleに未対応なので発生していると思われる。

本家のGitHubにissueを追加したところ、`go get github.com/oxequa/realize` の前に `go get gopkg.in/urfave/cli.v2@master` を追加する事で一時的に回避する方法を教えてもらったので、その方法で対応した。

https://github.com/oxequa/realize/issues/253

realizeのインストール時に `-u` を付けると同様のエラーが発生するので以下のように対応した。

```
go get gopkg.in/urfave/cli.v2@master
go get github.com/oxequa/realize
```