### PR TITLE
コンテナ内で常にテストを実行出来るように環境変数を設定

### DIFF
--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -21,6 +21,8 @@ ENV GO111MODULE on
 RUN set -eux && \
   go build -o portfolio-backend ./cmd/rest/main.go
 
+ENV CGO_ENABLED 0
+
 FROM alpine:3.11
 
 WORKDIR /app


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/portfolio-backend/issues/29

# Doneの定義
- `go test` を実行した時の `exec: "gcc": executable file not found in $PATH` が解消されテストが実行出来るようになっている事

# 変更点概要
- Dockerfile内に `ENV CGO_ENABLED 0` を追加