### PR TITLE
カバレッジの結果を集計出来るように改修

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -30,4 +30,14 @@ jobs:
           docker-compose exec -T go make lint
           docker-compose exec -T ${DB_HOST} service mysql status
           docker-compose exec -T go make migrate-up
-          docker-compose exec -T go make test
+          docker-compose exec -T go make test-ci
+      - name: Convert coverage to lcov
+        uses: jandelgado/gcov2lcov-action@v1.0.0
+        with:
+          infile: coverage.out
+          outfile: coverage.lcov
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coverage.lcov

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: migrate-up migrate-down lint test
+.PHONY: migrate-up migrate-down lint test test-ci
 
 migrate-up:
 	@migrate -source file://./_sql -database 'mysql://$(DB_USER):$(DB_PASSWORD)@tcp($(DB_HOST):3306)/$(DB_NAME)' up
@@ -12,3 +12,5 @@ lint:
 	@golangci-lint run ./...
 test:
 	@go test -v ./...
+test-ci:
+	@go test -v -coverprofile coverage.out -covermode atomic ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # portfolio-backend
 ![ci-master](https://github.com/nekochans/portfolio-backend/workflows/ci-master/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/nekochans/portfolio-backend/badge.svg?branch=master)](https://coveralls.io/github/nekochans/portfolio-backend?branch=master)
 
 GitHub Organization 「nekochans」の説明用Webサイトのバックエンド
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/portfolio-backend/issues/42

# 関連URL
https://coveralls.io/github/nekochans/portfolio-backend

# Doneの定義
- カバレッジの結果が集計され閲覧出来るようになっている事

# 変更点概要
- カバレッジを出力するテストタスクを定義

# 補足情報
以下の記事を参考にさせてもらった。

https://songmu.jp/riji/entry/2019-11-14-go-github-actions.html

`jandelgado/gcov2lcov-action` は公式Actionではないが実装がシンプルで使いやすそうなので、今回利用させてもらう事にした。