### PR TITLE
make lintの結果で差分があった場合、CIを失敗させるように変更

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,46 @@
 issues:
   exclude-use-default: false
 
+linters-settings:
+  funlen:
+    lines: 65
+    statements: 40
+
 linters:
   disable-all: true
   enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exhaustive
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
     - gofmt
     - goimports
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
     - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - scopelint
+    - staticcheck
+    - structcheck
     - typecheck
     - unconvert
     - unparam
     - unused
     - varcheck
     - whitespace
-    - noctx

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,3 +13,4 @@ linters:
     - unused
     - varcheck
     - whitespace
+    - noctx

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+issues:
+  exclude-use-default: false
+
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+    - goimports
+    - govet
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: migrate-up migrate-down lint test test-ci
+.PHONY: migrate-up migrate-down lint format test test-ci
 
 migrate-up:
 	@migrate -source file://./_sql -database 'mysql://$(DB_USER):$(DB_PASSWORD)@tcp($(DB_HOST):3306)/$(DB_NAME)' up

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ lint:
 	@golangci-lint run ./...
 format:
 	@gofmt -l -s -w .
+	@goimports -w -l ./
 test:
 	@go test -v ./...
 test-ci:

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ migrate-down:
 	@migrate -source file://./_sql -database 'mysql://${TEST_DB_USER}:${TEST_DB_PASSWORD}@tcp(${DB_HOST}:3306)/${TEST_DB_NAME}' down
 lint:
 	@go vet ./...
-	@gofmt -l -s -w .
 	@golangci-lint run ./...
+format:
+	@gofmt -l -s -w .
 test:
 	@go test -v ./...
 test-ci:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ docker-compose exec go make migrate-down
 
 `docker-push-to-gcr.sh` を実行して下さい。
 
-## ソースコードのフォーマット
+## Lintの実行
 
 `docker-compose exec go sh` でアプリケーション用のコンテナに入ります。
 
@@ -72,7 +72,19 @@ lintのルール等は以下を参考にして下さい。
 
 https://golangci-lint.run/usage/linters/
 
-内部でソースコードのフォーマットも行っていますが、自動で修正されない物は自分で修正を行う必要があります。
+ここで表示されたエラーは修正を行う必要があります。
+
+一部のエラー内容は後で解説する `make format` コマンドでも修正可能です。
+
+## ソースコードのフォーマット
+
+`docker-compose exec go sh` でアプリケーション用のコンテナに入ります。
+
+`make format` を実行して下さい。
+
+もしくは `docker-compose exec go make format` でも実行出来ます。
+
+このコマンドで自動修正されない物は自分で修正を行う必要があります。
 
 ## テストの実行
 

--- a/application/MemberScenario.go
+++ b/application/MemberScenario.go
@@ -29,10 +29,13 @@ type MemberFetchAllResponse struct {
 func (m *MemberScenario) FetchAll() *MemberFetchAllResponse {
 	var ms domain.Members
 
+	const keitaMemberId = 1
+	const mopMemberId = 2
+
 	ms = append(
 		ms,
 		&Openapi.Member{
-			Id:             1,
+			Id:             keitaMemberId,
 			GithubUserName: "keitakn",
 			GithubPicture:  "https://avatars1.githubusercontent.com/u/11032365?s=460&v=4",
 			CvUrl:          "https://github.com/keitakn/cv",
@@ -42,7 +45,7 @@ func (m *MemberScenario) FetchAll() *MemberFetchAllResponse {
 	ms = append(
 		ms,
 		&Openapi.Member{
-			Id:             2,
+			Id:             mopMemberId,
 			GithubUserName: "kobayashi-m42",
 			GithubPicture:  "https://avatars0.githubusercontent.com/u/32682645?s=460&v=4",
 			CvUrl:          "https://github.com/kobayashi-m42/cv",

--- a/application/MemberScenario_test.go
+++ b/application/MemberScenario_test.go
@@ -2,13 +2,14 @@ package application
 
 import (
 	"database/sql"
+	"path/filepath"
+	"reflect"
+	"testing"
+
 	"github.com/nekochans/portfolio-backend/domain"
 	"github.com/nekochans/portfolio-backend/infrastructure/repository"
 	Openapi "github.com/nekochans/portfolio-backend/openapi"
 	"github.com/nekochans/portfolio-backend/test"
-	"path/filepath"
-	"reflect"
-	"testing"
 )
 
 func fixtureTestMemberScenarioFetchFromMysqlSucceed(t *testing.T, db *sql.DB) {

--- a/application/WebServiceScenario_test.go
+++ b/application/WebServiceScenario_test.go
@@ -2,13 +2,14 @@ package application
 
 import (
 	"database/sql"
+	"path/filepath"
+	"reflect"
+	"testing"
+
 	"github.com/nekochans/portfolio-backend/domain"
 	"github.com/nekochans/portfolio-backend/infrastructure/repository"
 	Openapi "github.com/nekochans/portfolio-backend/openapi"
 	"github.com/nekochans/portfolio-backend/test"
-	"path/filepath"
-	"reflect"
-	"testing"
 )
 
 func TestWebServiceScenarioFetchAllFromMemorySucceed(t *testing.T) {

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -19,7 +19,8 @@ RUN set -eux && \
   go build -o /go/bin/dlv github.com/go-delve/delve/cmd/dlv && \
   go get -tags 'mysql' -u github.com/golang-migrate/migrate/cmd/migrate && \
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION} && \
-  go get github.com/deepmap/oapi-codegen/cmd/oapi-codegen
+  go get github.com/deepmap/oapi-codegen/cmd/oapi-codegen && \
+  go get golang.org/x/tools/cmd/goimports
 
 ENV GO111MODULE on
 

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 
 ENV GO111MODULE=off
 
-ARG GOLANGCI_LINT_VERSION=v1.27.0
+ARG GOLANGCI_LINT_VERSION=v1.29.0
 
 RUN set -eux && \
   apk update && \

--- a/infrastructure/HttpErrorCreator.go
+++ b/infrastructure/HttpErrorCreator.go
@@ -9,8 +9,8 @@ func (h *HttpErrorCreator) CreateFromMsg(msg string) Openapi.Error {
 	message := "Internal Server Error"
 
 	m := map[string]int{
-		"MysqlMemberRepository.Find: Member Not Found":     404,
-		"MysqlMemberRepository.FindAll: Members Not Found": 404,
+		"MysqlMemberRepository.Find: Member Not Found":             404,
+		"MysqlMemberRepository.FindAll: Members Not Found":         404,
 		"MysqlWebServiceRepository.FindAll: WebServices Not Found": 404,
 	}
 

--- a/infrastructure/HttpErrorCreator.go
+++ b/infrastructure/HttpErrorCreator.go
@@ -5,13 +5,16 @@ import Openapi "github.com/nekochans/portfolio-backend/openapi"
 type HttpErrorCreator struct{}
 
 func (h *HttpErrorCreator) CreateFromMsg(msg string) Openapi.Error {
-	code := 500
+	const notFoundErrorCode = 404
+	const internalServerErrorCode = 500
+
+	code := internalServerErrorCode
 	message := "Internal Server Error"
 
 	m := map[string]int{
-		"MysqlMemberRepository.Find: Member Not Found":             404,
-		"MysqlMemberRepository.FindAll: Members Not Found":         404,
-		"MysqlWebServiceRepository.FindAll: WebServices Not Found": 404,
+		"MysqlMemberRepository.Find: Member Not Found":             notFoundErrorCode,
+		"MysqlMemberRepository.FindAll: Members Not Found":         notFoundErrorCode,
+		"MysqlWebServiceRepository.FindAll: WebServices Not Found": notFoundErrorCode,
 	}
 
 	if m[msg] != 0 {

--- a/infrastructure/HttpResponse.go
+++ b/infrastructure/HttpResponse.go
@@ -23,7 +23,7 @@ func CreateJsonResponse(w http.ResponseWriter, r *http.Request, status int, payl
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("X-Request-Id", middleware.GetReqID(r.Context()))
 	w.WriteHeader(status)
-	_, err = w.Write([]byte(res))
+	_, err = w.Write(res)
 	if err != nil {
 		log.Fatal(err, "http.ResponseWriter() Fatal.")
 	}

--- a/infrastructure/HttpResponse.go
+++ b/infrastructure/HttpResponse.go
@@ -2,10 +2,11 @@ package infrastructure
 
 import (
 	"encoding/json"
-	"github.com/go-chi/chi/middleware"
-	"go.uber.org/zap"
 	"log"
 	"net/http"
+
+	"github.com/go-chi/chi/middleware"
+	"go.uber.org/zap"
 )
 
 func CreateJsonResponse(w http.ResponseWriter, r *http.Request, status int, payload interface{}) {

--- a/infrastructure/HttpServer.go
+++ b/infrastructure/HttpServer.go
@@ -38,11 +38,7 @@ func (hs *HttpServer) GetMembers(w http.ResponseWriter, r *http.Request) {
 	CreateJsonResponse(w, r, http.StatusOK, ml)
 }
 
-func (hs *HttpServer) GetMemberById(w http.ResponseWriter, r *http.Request) {
-	hs.HttpHandler = Openapi.GetMemberByIdCtx(hs.HttpHandler)
-
-	id := r.Context().Value("id").(int)
-
+func (hs *HttpServer) GetMemberById(w http.ResponseWriter, r *http.Request, id int) {
 	repo := &repository.MysqlMemberRepository{Db: hs.Db}
 	ms := application.MemberScenario{MemberRepository: repo}
 

--- a/infrastructure/HttpServer.go
+++ b/infrastructure/HttpServer.go
@@ -67,10 +67,12 @@ func (hs *HttpServer) GetWebservices(w http.ResponseWriter, r *http.Request) {
 }
 
 func (hs *HttpServer) middleware() {
+	const timeoutSecond = 60
+
 	hs.Router.Use(middleware.RequestID)
 	hs.Router.Use(Logger(hs.Logger))
 	hs.Router.Use(middleware.Recoverer)
-	hs.Router.Use(middleware.Timeout(time.Second * 60))
+	hs.Router.Use(middleware.Timeout(time.Second * timeoutSecond))
 }
 
 func (hs *HttpServer) Init(env string) {

--- a/infrastructure/HttpServer.go
+++ b/infrastructure/HttpServer.go
@@ -4,6 +4,10 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"log"
+	"net/http"
+	"time"
+
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/nekochans/portfolio-backend/application"
@@ -11,9 +15,6 @@ import (
 	"github.com/nekochans/portfolio-backend/infrastructure/repository"
 	Openapi "github.com/nekochans/portfolio-backend/openapi"
 	"go.uber.org/zap"
-	"log"
-	"net/http"
-	"time"
 )
 
 type HttpServer struct {

--- a/infrastructure/Logger.go
+++ b/infrastructure/Logger.go
@@ -1,11 +1,12 @@
 package infrastructure
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/go-chi/chi/middleware"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"net/http"
-	"time"
 )
 
 func Logger(l *zap.Logger) func(next http.Handler) http.Handler {

--- a/infrastructure/repository/MysqlMemberRepository.go
+++ b/infrastructure/repository/MysqlMemberRepository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"database/sql"
+	"log"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/nekochans/portfolio-backend/domain"
@@ -44,7 +45,12 @@ func (m *MysqlMemberRepository) Find(id int) (*Openapi.Member, error) {
 		return nil, xerrors.Errorf("MysqlMemberRepository.Find: %w", appErr)
 	}
 
-	defer stmt.Close()
+	defer func() {
+		err := stmt.Close()
+		if err != nil {
+			log.Fatal(err, "stmt.Close() Fatal.")
+		}
+	}()
 
 	var tableData FindTableData
 
@@ -101,7 +107,12 @@ func (m *MysqlMemberRepository) FindAll() (domain.Members, error) {
 		return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", appErr)
 	}
 
-	defer stmt.Close()
+	defer func() {
+		err := stmt.Close()
+		if err != nil {
+			log.Fatal(err, "stmt.Close() Fatal.")
+		}
+	}()
 
 	rows, err := stmt.Query()
 

--- a/infrastructure/repository/MysqlMemberRepository.go
+++ b/infrastructure/repository/MysqlMemberRepository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"database/sql"
+
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/nekochans/portfolio-backend/domain"
 	Openapi "github.com/nekochans/portfolio-backend/openapi"

--- a/infrastructure/repository/MysqlWebServiceRepository.go
+++ b/infrastructure/repository/MysqlWebServiceRepository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"database/sql"
+	"log"
 
 	"github.com/nekochans/portfolio-backend/domain"
 	Openapi "github.com/nekochans/portfolio-backend/openapi"
@@ -37,7 +38,12 @@ func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", appErr)
 	}
 
-	defer stmt.Close()
+	defer func() {
+		err := stmt.Close()
+		if err != nil {
+			log.Fatal(err, "stmt.Close() Fatal.")
+		}
+	}()
 
 	rows, err := stmt.Query()
 

--- a/infrastructure/repository/MysqlWebServiceRepository.go
+++ b/infrastructure/repository/MysqlWebServiceRepository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"database/sql"
+
 	"github.com/nekochans/portfolio-backend/domain"
 	Openapi "github.com/nekochans/portfolio-backend/openapi"
 	"golang.org/x/xerrors"

--- a/openapi/Server.gen.go
+++ b/openapi/Server.gen.go
@@ -6,9 +6,10 @@ package Openapi
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
 	"github.com/go-chi/chi"
-	"net/http"
 )
 
 type ServerInterface interface {

--- a/test/DbCreator.go
+++ b/test/DbCreator.go
@@ -2,8 +2,9 @@ package test
 
 import (
 	"database/sql"
-	"github.com/nekochans/portfolio-backend/config"
 	"testing"
+
+	"github.com/nekochans/portfolio-backend/config"
 )
 
 type DbCreator struct{}

--- a/test/Seeder.go
+++ b/test/Seeder.go
@@ -3,10 +3,11 @@ package test
 import (
 	"database/sql"
 	"fmt"
-	"github.com/go-sql-driver/mysql"
 	"io/ioutil"
 	"log"
 	"path/filepath"
+
+	"github.com/go-sql-driver/mysql"
 )
 
 type Seeder struct {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/portfolio-backend/issues/48

# Doneの定義
- https://github.com/nekochans/portfolio-backend/issues/48 の完了の定義を満たしている事

# 変更点概要
- `lint` と `format` を別のコマンドとして実施
- `format` 時に `goimports` を実行するように改修
- `golangci-lint` の設定で設定しておいたほうが良い項目があったので設定ファイルを追加
- `format` の結果をコミット、警告が出た箇所を全て修正

# 補足情報
`golangci-lint` の設定ファイル

https://golangci-lint.run/usage/configuration/