### PR TITLE
airのインストール方法を修正しdocker-compose upが出来るように修正

### DIFF
--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -13,8 +13,8 @@ ARG GOLANGCI_LINT_VERSION=v1.29.0
 RUN set -eux && \
   apk update && \
   apk add --no-cache git curl make && \
-  curl -fLo /go/bin/air https://git.io/linux_air && \
-  chmod +x /go/bin/air && \
+  go get -u github.com/cosmtrek/air && \
+  go build -o /go/bin/air github.com/cosmtrek/air && \
   go get -u github.com/go-delve/delve/cmd/dlv && \
   go build -o /go/bin/dlv github.com/go-delve/delve/cmd/dlv && \
   go get -tags 'mysql' -u github.com/golang-migrate/migrate/cmd/migrate && \


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/portfolio-backend/issues/52

# Doneの定義
- airのインストールに失敗している現象が解消されている事

# スクリーンショット

以下のように正常にデバッガーを使える事を確認済

![debug](https://user-images.githubusercontent.com/11032365/89702118-76c2c400-d978-11ea-9afb-40559a90282d.png)

# 変更点概要
- airをインストールする際にgo getを使うように変更