### PR TITLE
変数名や引数名等をGoの慣例に合わせて修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ format:
 	@gofmt -l -s -w .
 	@goimports -w -l ./
 test:
+	@go clean -testcache
 	@go test -v ./...
 test-ci:
 	@go test -v -coverprofile coverage.out -covermode atomic ./...

--- a/application/member_scenario.go
+++ b/application/member_scenario.go
@@ -27,13 +27,13 @@ type MemberFetchAllResponse struct {
 }
 
 func (m *MemberScenario) FetchAll() *MemberFetchAllResponse {
-	var ms domain.Members
+	var item domain.Members
 
 	const keitaMemberId = 1
 	const mopMemberId = 2
 
-	ms = append(
-		ms,
+	item = append(
+		item,
 		&Openapi.Member{
 			Id:             keitaMemberId,
 			GithubUserName: "keitakn",
@@ -42,8 +42,8 @@ func (m *MemberScenario) FetchAll() *MemberFetchAllResponse {
 		},
 	)
 
-	ms = append(
-		ms,
+	item = append(
+		item,
 		&Openapi.Member{
 			Id:             mopMemberId,
 			GithubUserName: "kobayashi-m42",
@@ -52,7 +52,7 @@ func (m *MemberScenario) FetchAll() *MemberFetchAllResponse {
 		},
 	)
 
-	return &MemberFetchAllResponse{Items: ms}
+	return &MemberFetchAllResponse{Items: item}
 }
 
 func (m *MemberScenario) FetchAllFromMysql() (*MemberFetchAllResponse, error) {

--- a/application/member_scenario_test.go
+++ b/application/member_scenario_test.go
@@ -13,20 +13,20 @@ import (
 )
 
 func fixtureTestMemberScenarioFetchFromMysqlSucceed(t *testing.T, db *sql.DB) {
-	testDataDir, err := filepath.Abs("../test/data/memberscenario/fetchfrommysql/succeed")
-	if err != nil {
-		t.Fatal("fixtureTestMemberScenarioFetchFromMysqlSucceed Error", err)
+	testDataDir, ErrFilepath := filepath.Abs("../test/data/memberscenario/fetchfrommysql/succeed")
+	if ErrFilepath != nil {
+		t.Fatal("fixtureTestMemberScenarioFetchFromMysqlSucceed Error", ErrFilepath)
 	}
 
 	seeder := &test.Seeder{Db: db, DirPath: testDataDir}
-	err = seeder.TruncateAllTable()
-	if err != nil {
-		t.Fatal("fixtureTestMemberScenarioFetchFromMysqlSucceed Error", err)
+	ErrTruncate := seeder.TruncateAllTable()
+	if ErrTruncate != nil {
+		t.Fatal("fixtureTestMemberScenarioFetchFromMysqlSucceed Error", ErrTruncate)
 	}
 
-	err = seeder.Execute()
-	if err != nil {
-		t.Fatal("fixtureTestMemberScenarioFetchFromMysqlSucceed Error", err)
+	ErrSeeder := seeder.Execute()
+	if ErrSeeder != nil {
+		t.Fatal("fixtureTestMemberScenarioFetchFromMysqlSucceed Error", ErrSeeder)
 	}
 }
 
@@ -39,20 +39,20 @@ func fixtureTestMemberScenarioFetchFromMysqlFailureMembersNotFound(t *testing.T,
 }
 
 func fixtureTestMemberScenarioFetchAllFromMysqlSucceed(t *testing.T, db *sql.DB) {
-	testDataDir, err := filepath.Abs("../test/data/memberscenario/fetchallfrommysql/succeed")
-	if err != nil {
-		t.Fatal("fixtureTestMemberScenarioFetchAllFromMysqlSucceed Error", err)
+	testDataDir, ErrFilepath := filepath.Abs("../test/data/memberscenario/fetchallfrommysql/succeed")
+	if ErrFilepath != nil {
+		t.Fatal("fixtureTestMemberScenarioFetchAllFromMysqlSucceed Error", ErrFilepath)
 	}
 
 	seeder := &test.Seeder{Db: db, DirPath: testDataDir}
-	err = seeder.TruncateAllTable()
-	if err != nil {
-		t.Fatal("fixtureTestMemberScenarioFetchAllFromMysqlSucceed Error", err)
+	ErrTruncate := seeder.TruncateAllTable()
+	if ErrTruncate != nil {
+		t.Fatal("fixtureTestMemberScenarioFetchAllFromMysqlSucceed Error", ErrTruncate)
 	}
 
-	err = seeder.Execute()
-	if err != nil {
-		t.Fatal("fixtureTestMemberScenarioFetchAllFromMysqlSucceed Error", err)
+	ErrSeeder := seeder.Execute()
+	if ErrSeeder != nil {
+		t.Fatal("fixtureTestMemberScenarioFetchAllFromMysqlSucceed Error", ErrSeeder)
 	}
 }
 

--- a/application/member_scenario_test.go
+++ b/application/member_scenario_test.go
@@ -77,10 +77,10 @@ func TestMemberScenarioFetchFromMysqlSucceed(t *testing.T) {
 	}
 
 	repo := &repository.MysqlMemberRepository{Db: db}
-	ms := &MemberScenario{MemberRepository: repo}
+	scenario := &MemberScenario{MemberRepository: repo}
 	req := &MemberFetchRequest{Id: 1}
 
-	res, err := ms.FetchFromMysql(*req)
+	res, err := scenario.FetchFromMysql(*req)
 
 	if err != nil {
 		t.Error("\nActually: ", err, "\nExpected: ", expected)
@@ -97,10 +97,10 @@ func TestMemberScenarioFetchFromMysqlFailureMemberNotFound(t *testing.T) {
 	fixtureTestMemberScenarioFetchFromMysqlFailureMembersNotFound(t, db)
 
 	repo := &repository.MysqlMemberRepository{Db: db}
-	ms := &MemberScenario{MemberRepository: repo}
+	scenario := &MemberScenario{MemberRepository: repo}
 	req := &MemberFetchRequest{Id: 99}
 
-	res, err := ms.FetchFromMysql(*req)
+	res, err := scenario.FetchFromMysql(*req)
 	expected := "MysqlMemberRepository.Find: Member Not Found"
 
 	if res != nil {
@@ -137,8 +137,8 @@ func TestMemberScenarioFetchAllMemorySucceed(t *testing.T) {
 		},
 	)
 
-	ms := &MemberScenario{}
-	res := ms.FetchAll()
+	scenario := &MemberScenario{}
+	res := scenario.FetchAll()
 
 	for i, member := range res.Items {
 		if reflect.DeepEqual(member, expected[i]) == false {
@@ -153,8 +153,8 @@ func TestMemberScenarioFetchAllFromMysqlSucceed(t *testing.T) {
 	fixtureTestMemberScenarioFetchAllFromMysqlSucceed(t, db)
 
 	repo := &repository.MysqlMemberRepository{Db: db}
-	ms := &MemberScenario{MemberRepository: repo}
-	res, err := ms.FetchAllFromMysql()
+	scenario := &MemberScenario{MemberRepository: repo}
+	res, err := scenario.FetchAllFromMysql()
 
 	var expected domain.Members
 
@@ -191,8 +191,8 @@ func TestMemberScenarioFetchAllFromMysqlFailureMembersNotFound(t *testing.T) {
 	fixtureTestMemberScenarioFetchAllFromMysqlFailureMembersNotFound(t, db)
 
 	repo := &repository.MysqlMemberRepository{Db: db}
-	ms := &MemberScenario{MemberRepository: repo}
-	res, err := ms.FetchAllFromMysql()
+	scenario := &MemberScenario{MemberRepository: repo}
+	res, err := scenario.FetchAllFromMysql()
 	expected := "MysqlMemberRepository.FindAll: Members Not Found"
 
 	if res != nil {

--- a/application/web_service_scenario.go
+++ b/application/web_service_scenario.go
@@ -14,10 +14,10 @@ type WebServiceFetchAllResponse struct {
 }
 
 func (w *WebServiceScenario) FetchAll() *WebServiceFetchAllResponse {
-	var ws domain.WebServices
+	var item domain.WebServices
 
-	ws = append(
-		ws,
+	item = append(
+		item,
 		&Openapi.WebService{
 			Id:          1,
 			Url:         "https://www.mindexer.net",
@@ -25,7 +25,7 @@ func (w *WebServiceScenario) FetchAll() *WebServiceFetchAllResponse {
 		},
 	)
 
-	return &WebServiceFetchAllResponse{Items: ws}
+	return &WebServiceFetchAllResponse{Items: item}
 }
 
 func (w *WebServiceScenario) FetchAllFromMysql() (*WebServiceFetchAllResponse, error) {

--- a/application/web_service_scenario_test.go
+++ b/application/web_service_scenario_test.go
@@ -24,8 +24,8 @@ func TestWebServiceScenarioFetchAllFromMemorySucceed(t *testing.T) {
 		},
 	)
 
-	ws := &WebServiceScenario{}
-	res := ws.FetchAll()
+	scenario := &WebServiceScenario{}
+	res := scenario.FetchAll()
 
 	for i, webService := range res.Items {
 		if reflect.DeepEqual(webService, expected[i]) == false {
@@ -66,8 +66,8 @@ func TestWebServiceScenarioFetchAllFromMysqlSucceed(t *testing.T) {
 	fixtureTestWebServiceScenarioFetchAllFromMysqlSucceed(t, db)
 
 	repo := &repository.MysqlWebServiceRepository{Db: db}
-	ws := &WebServiceScenario{WebServiceRepository: repo}
-	res, err := ws.FetchAllFromMysql()
+	scenario := &WebServiceScenario{WebServiceRepository: repo}
+	res, err := scenario.FetchAllFromMysql()
 
 	var expected domain.WebServices
 
@@ -97,8 +97,8 @@ func TestWebServiceScenarioFetchAllFromMysqlFailureWebServicesNotFound(t *testin
 	fixtureTestWebServiceScenarioFetchAllFromMysqlFailureWebServicesNotFound(t, db)
 
 	repo := &repository.MysqlWebServiceRepository{Db: db}
-	ws := &WebServiceScenario{WebServiceRepository: repo}
-	res, err := ws.FetchAllFromMysql()
+	scenario := &WebServiceScenario{WebServiceRepository: repo}
+	res, err := scenario.FetchAllFromMysql()
 	expected := "MysqlWebServiceRepository.FindAll: WebServices Not Found"
 
 	if res != nil {

--- a/application/web_service_scenario_test.go
+++ b/application/web_service_scenario_test.go
@@ -35,20 +35,20 @@ func TestWebServiceScenarioFetchAllFromMemorySucceed(t *testing.T) {
 }
 
 func fixtureTestWebServiceScenarioFetchAllFromMysqlSucceed(t *testing.T, db *sql.DB) {
-	testDataDir, err := filepath.Abs("../test/data/webservicescenario/fetchallfrommysql/succeed")
-	if err != nil {
-		t.Fatal("fixtureTestWebServiceScenarioFetchAllFromMysqlSucceed Error", err)
+	testDataDir, ErrFilepath := filepath.Abs("../test/data/webservicescenario/fetchallfrommysql/succeed")
+	if ErrFilepath != nil {
+		t.Fatal("fixtureTestWebServiceScenarioFetchAllFromMysqlSucceed Error", ErrFilepath)
 	}
 
 	seeder := &test.Seeder{Db: db, DirPath: testDataDir}
-	err = seeder.TruncateAllTable()
-	if err != nil {
-		t.Fatal("fixtureTestWebServiceScenarioFetchAllFromMysqlSucceed Error", err)
+	ErrTruncate := seeder.TruncateAllTable()
+	if ErrTruncate != nil {
+		t.Fatal("fixtureTestWebServiceScenarioFetchAllFromMysqlSucceed Error", ErrTruncate)
 	}
 
-	err = seeder.Execute()
-	if err != nil {
-		t.Fatal("fixtureTestWebServiceScenarioFetchAllFromMysqlSucceed Error", err)
+	ErrSeeder := seeder.Execute()
+	if ErrSeeder != nil {
+		t.Fatal("fixtureTestWebServiceScenarioFetchAllFromMysqlSucceed Error", ErrSeeder)
 	}
 }
 

--- a/domain/backend_error.go
+++ b/domain/backend_error.go
@@ -1,10 +1,10 @@
 package domain
 
 type BackendError struct {
-	Msg string
-	Err error
+	Message string
+	Err     error
 }
 
 func (e *BackendError) Error() string {
-	return e.Msg
+	return e.Message
 }

--- a/infrastructure/http_error_creator.go
+++ b/infrastructure/http_error_creator.go
@@ -22,10 +22,10 @@ func (h *HttpErrorCreator) CreateFromMsg(msg string) Openapi.Error {
 		message = msg
 	}
 
-	he := Openapi.Error{
+	err := Openapi.Error{
 		Code:    code,
 		Message: message,
 	}
 
-	return he
+	return err
 }

--- a/infrastructure/http_response.go
+++ b/infrastructure/http_response.go
@@ -10,12 +10,12 @@ import (
 )
 
 func CreateJsonResponse(w http.ResponseWriter, r *http.Request, status int, payload interface{}) {
-	res, err := json.MarshalIndent(payload, "", "    ")
-	if err != nil {
+	res, ErrJsonEncode := json.MarshalIndent(payload, "", "    ")
+	if ErrJsonEncode != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		_, err := w.Write([]byte(err.Error()))
-		if err != nil {
-			log.Fatal(err, "http.ResponseWriter() Fatal.")
+		_, ErrWriteResponse := w.Write([]byte(ErrJsonEncode.Error()))
+		if ErrWriteResponse != nil {
+			log.Fatal(ErrWriteResponse, "http.ResponseWriter() Fatal.")
 		}
 		return
 	}
@@ -23,9 +23,9 @@ func CreateJsonResponse(w http.ResponseWriter, r *http.Request, status int, payl
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("X-Request-Id", middleware.GetReqID(r.Context()))
 	w.WriteHeader(status)
-	_, err = w.Write(res)
-	if err != nil {
-		log.Fatal(err, "http.ResponseWriter() Fatal.")
+	_, ErrWriteHeader := w.Write(res)
+	if ErrWriteHeader != nil {
+		log.Fatal(ErrWriteHeader, "http.ResponseWriter() Fatal.")
 	}
 }
 

--- a/infrastructure/http_response.go
+++ b/infrastructure/http_response.go
@@ -34,7 +34,7 @@ func CreateErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
 	logger := CreateLogger()
 	logger.Error(err.Error(), zap.String("RequestId", middleware.GetReqID(r.Context())))
 
-	hc := &HttpErrorCreator{}
-	he := hc.CreateFromMsg(err.Error())
-	CreateJsonResponse(w, r, he.Code, he)
+	errCreator := &HttpErrorCreator{}
+	httpError := errCreator.CreateFromMsg(err.Error())
+	CreateJsonResponse(w, r, httpError.Code, httpError)
 }

--- a/infrastructure/http_server.go
+++ b/infrastructure/http_server.go
@@ -104,17 +104,17 @@ func StartHttpServer() {
 
 	logger := CreateLogger()
 	defer func() {
-		err := logger.Sync()
-		if err != nil {
-			loggerSyncErr := xerrors.Errorf("Unable to connect to MySQL server: %w", err)
-			logger.Error(err.Error(), zap.Error(loggerSyncErr))
+		ErrSync := logger.Sync()
+		if ErrSync != nil {
+			ErrLoggerSync := xerrors.Errorf("Failed to logger Sync: %w", ErrSync)
+			logger.Error(ErrSync.Error(), zap.Error(ErrLoggerSync))
 		}
 	}()
 
-	db, err := sql.Open("mysql", config.GetDsn())
-	if err != nil {
-		mysqlErr := xerrors.Errorf("Unable to connect to MySQL server: %w", err)
-		logger.Error(err.Error(), zap.Error(mysqlErr))
+	db, ErrConnectDb := sql.Open("mysql", config.GetDsn())
+	if ErrConnectDb != nil {
+		mysqlErr := xerrors.Errorf("Unable to connect to MySQL server: %w", ErrConnectDb)
+		logger.Error(ErrConnectDb.Error(), zap.Error(mysqlErr))
 	}
 
 	r := chi.NewRouter()

--- a/infrastructure/http_server.go
+++ b/infrastructure/http_server.go
@@ -25,40 +25,40 @@ type HttpServer struct {
 	Logger      *zap.Logger
 }
 
-func (hs *HttpServer) GetMembers(w http.ResponseWriter, r *http.Request) {
-	repo := &repository.MysqlMemberRepository{Db: hs.Db}
+func (s *HttpServer) GetMembers(w http.ResponseWriter, r *http.Request) {
+	repo := &repository.MysqlMemberRepository{Db: s.Db}
 
-	ms := application.MemberScenario{MemberRepository: repo}
-	ml, err := ms.FetchAllFromMysql()
+	scenario := application.MemberScenario{MemberRepository: repo}
+	members, err := scenario.FetchAllFromMysql()
 
 	if err != nil {
 		CreateErrorResponse(w, r, err)
 		return
 	}
 
-	CreateJsonResponse(w, r, http.StatusOK, ml)
+	CreateJsonResponse(w, r, http.StatusOK, members)
 }
 
-func (hs *HttpServer) GetMemberById(w http.ResponseWriter, r *http.Request, id int) {
-	repo := &repository.MysqlMemberRepository{Db: hs.Db}
-	ms := application.MemberScenario{MemberRepository: repo}
+func (s *HttpServer) GetMemberById(w http.ResponseWriter, r *http.Request, id int) {
+	repo := &repository.MysqlMemberRepository{Db: s.Db}
+	scenario := application.MemberScenario{MemberRepository: repo}
 
 	req := &application.MemberFetchRequest{Id: id}
-	me, err := ms.FetchFromMysql(*req)
+	member, err := scenario.FetchFromMysql(*req)
 	if err != nil {
 		CreateErrorResponse(w, r, err)
 		return
 	}
 
-	CreateJsonResponse(w, r, http.StatusOK, me)
+	CreateJsonResponse(w, r, http.StatusOK, member)
 }
 
-func (hs *HttpServer) GetWebservices(w http.ResponseWriter, r *http.Request) {
-	repo := &repository.MysqlWebServiceRepository{Db: hs.Db}
+func (s *HttpServer) GetWebservices(w http.ResponseWriter, r *http.Request) {
+	repo := &repository.MysqlWebServiceRepository{Db: s.Db}
 
-	ws := &application.WebServiceScenario{WebServiceRepository: repo}
+	scenario := &application.WebServiceScenario{WebServiceRepository: repo}
 
-	res, err := ws.FetchAllFromMysql()
+	res, err := scenario.FetchAllFromMysql()
 	if err != nil {
 		CreateErrorResponse(w, r, err)
 		return
@@ -67,31 +67,31 @@ func (hs *HttpServer) GetWebservices(w http.ResponseWriter, r *http.Request) {
 	CreateJsonResponse(w, r, http.StatusOK, res)
 }
 
-func (hs *HttpServer) middleware() {
+func (s *HttpServer) middleware() {
 	const timeoutSecond = 60
 
-	hs.Router.Use(middleware.RequestID)
-	hs.Router.Use(Logger(hs.Logger))
-	hs.Router.Use(middleware.Recoverer)
-	hs.Router.Use(middleware.Timeout(time.Second * timeoutSecond))
+	s.Router.Use(middleware.RequestID)
+	s.Router.Use(Logger(s.Logger))
+	s.Router.Use(middleware.Recoverer)
+	s.Router.Use(middleware.Timeout(time.Second * timeoutSecond))
 }
 
-func (hs *HttpServer) Init(env string) {
-	hs.middleware()
+func (s *HttpServer) Init(env string) {
+	s.middleware()
 }
 
-func NewHttpServer(logger *zap.Logger, router *chi.Mux) *HttpServer {
+func NewHttpServer(l *zap.Logger, r *chi.Mux) *HttpServer {
 	return &HttpServer{
-		Router: router,
-		Logger: logger,
+		Router: r,
+		Logger: l,
 	}
 }
 
-func NewHttpServerWithMysql(db *sql.DB, logger *zap.Logger, router *chi.Mux) *HttpServer {
+func NewHttpServerWithMysql(d *sql.DB, l *zap.Logger, r *chi.Mux) *HttpServer {
 	return &HttpServer{
-		Router: router,
-		Db:     db,
-		Logger: logger,
+		Router: r,
+		Db:     d,
+		Logger: l,
 	}
 }
 
@@ -117,12 +117,12 @@ func StartHttpServer() {
 		logger.Error(ErrConnectDb.Error(), zap.Error(ErrMysqlConnect))
 	}
 
-	r := chi.NewRouter()
-	s := NewHttpServerWithMysql(db, logger, r)
-	s.Init(*env)
+	router := chi.NewRouter()
+	server := NewHttpServerWithMysql(db, logger, router)
+	server.Init(*env)
 
-	s.HttpHandler = Openapi.HandlerFromMux(s, s.Router)
+	server.HttpHandler = Openapi.HandlerFromMux(server, server.Router)
 
 	log.Println("Starting app")
-	_ = http.ListenAndServe(fmt.Sprint(":", *port), s.Router)
+	_ = http.ListenAndServe(fmt.Sprint(":", *port), server.Router)
 }

--- a/infrastructure/http_server.go
+++ b/infrastructure/http_server.go
@@ -113,8 +113,8 @@ func StartHttpServer() {
 
 	db, ErrConnectDb := sql.Open("mysql", config.GetDsn())
 	if ErrConnectDb != nil {
-		mysqlErr := xerrors.Errorf("Unable to connect to MySQL server: %w", ErrConnectDb)
-		logger.Error(ErrConnectDb.Error(), zap.Error(mysqlErr))
+		ErrMysqlConnect := xerrors.Errorf("Unable to connect to MySQL server: %w", ErrConnectDb)
+		logger.Error(ErrConnectDb.Error(), zap.Error(ErrMysqlConnect))
 	}
 
 	r := chi.NewRouter()

--- a/infrastructure/logger.go
+++ b/infrastructure/logger.go
@@ -12,21 +12,21 @@ import (
 func Logger(l *zap.Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
-			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			writer := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 
-			t1 := time.Now()
+			now := time.Now()
 			defer func() {
 				// TODO r.Bodyをログに出したほうが良さそう
 				l.Info("message",
 					zap.String("protocol", r.Proto),
 					zap.String("path", r.URL.Path),
-					zap.Duration("lat", time.Since(t1)),
-					zap.Int("HttpStatus", ww.Status()),
-					zap.Int("size", ww.BytesWritten()),
+					zap.Duration("lat", time.Since(now)),
+					zap.Int("HttpStatus", writer.Status()),
+					zap.Int("size", writer.BytesWritten()),
 					zap.String("RequestId", middleware.GetReqID(r.Context())))
 			}()
 
-			next.ServeHTTP(ww, r)
+			next.ServeHTTP(writer, r)
 		}
 		return http.HandlerFunc(fn)
 	}
@@ -44,8 +44,8 @@ func CreateLogger() *zap.Logger {
 			LevelKey:       "level",
 			NameKey:        "name",
 			CallerKey:      "caller",
-			MessageKey:     "msg",
-			StacktraceKey:  "st",
+			MessageKey:     "message",
+			StacktraceKey:  "stackTrace",
 			EncodeLevel:    zapcore.CapitalLevelEncoder,
 			EncodeTime:     zapcore.ISO8601TimeEncoder,
 			EncodeDuration: zapcore.StringDurationEncoder,

--- a/infrastructure/repository/mysql_member_repository.go
+++ b/infrastructure/repository/mysql_member_repository.go
@@ -22,7 +22,7 @@ type FindTableData struct {
 }
 
 func (m *MysqlMemberRepository) Find(id int) (*Openapi.Member, error) {
-	sql := `
+	query := `
 		SELECT
 		  m.id AS Id,
 		  mgu.github_id AS GithubId,
@@ -38,7 +38,7 @@ func (m *MysqlMemberRepository) Find(id int) (*Openapi.Member, error) {
 			m.id = ?
 	`
 
-	stmt, ErrPrepare := m.Db.Prepare(sql)
+	stmt, ErrPrepare := m.Db.Prepare(query)
 
 	if ErrPrepare != nil {
 		ErrBackend := &domain.BackendError{Msg: "Db.Prepare Error", Err: ErrPrepare}
@@ -66,14 +66,14 @@ func (m *MysqlMemberRepository) Find(id int) (*Openapi.Member, error) {
 		return nil, xerrors.Errorf("MysqlMemberRepository.Find: %w", ErrBackend)
 	}
 
-	me := &Openapi.Member{
+	member := &Openapi.Member{
 		Id:             tableData.Id,
 		GithubUserName: tableData.GithubId,
 		GithubPicture:  tableData.AvatarUrl,
 		CvUrl:          "https://github.com/" + tableData.GithubId + "/" + tableData.CvRepoName,
 	}
 
-	return me, nil
+	return member, nil
 }
 
 type FindAllTableData struct {
@@ -84,7 +84,7 @@ type FindAllTableData struct {
 }
 
 func (m *MysqlMemberRepository) FindAll() (domain.Members, error) {
-	sql := `
+	query := `
 		SELECT
 		  m.id AS Id,
 		  mgu.github_id AS GithubId,
@@ -101,7 +101,7 @@ func (m *MysqlMemberRepository) FindAll() (domain.Members, error) {
 		ASC
 	`
 
-	stmt, ErrPrepare := m.Db.Prepare(sql)
+	stmt, ErrPrepare := m.Db.Prepare(query)
 	if ErrPrepare != nil {
 		ErrBackend := &domain.BackendError{Msg: "Db.Prepare Error", Err: ErrPrepare}
 		return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", ErrBackend)
@@ -122,11 +122,11 @@ func (m *MysqlMemberRepository) FindAll() (domain.Members, error) {
 	}
 
 	var tableData FindAllTableData
-	var ms domain.Members
+	var members domain.Members
 	for rows.Next() {
 		ErrRowsScan := rows.Scan(&tableData.Id, &tableData.GithubId, &tableData.AvatarUrl, &tableData.CvRepoName)
-		ms = append(
-			ms,
+		members = append(
+			members,
 			&Openapi.Member{
 				Id:             tableData.Id,
 				GithubUserName: tableData.GithubId,
@@ -147,5 +147,5 @@ func (m *MysqlMemberRepository) FindAll() (domain.Members, error) {
 		return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", ErrBackend)
 	}
 
-	return ms, nil
+	return members, nil
 }

--- a/infrastructure/repository/mysql_member_repository.go
+++ b/infrastructure/repository/mysql_member_repository.go
@@ -41,8 +41,8 @@ func (m *MysqlMemberRepository) Find(id int) (*Openapi.Member, error) {
 	stmt, ErrPrepare := m.Db.Prepare(sql)
 
 	if ErrPrepare != nil {
-		appErr := &domain.BackendError{Msg: "Db.Prepare Error", Err: ErrPrepare}
-		return nil, xerrors.Errorf("MysqlMemberRepository.Find: %w", appErr)
+		ErrBackend := &domain.BackendError{Msg: "Db.Prepare Error", Err: ErrPrepare}
+		return nil, xerrors.Errorf("MysqlMemberRepository.Find: %w", ErrBackend)
 	}
 
 	defer func() {
@@ -58,12 +58,12 @@ func (m *MysqlMemberRepository) Find(id int) (*Openapi.Member, error) {
 	if ErrQuery != nil {
 		// この条件の時はデータが1件も存在しない
 		if ErrQuery.Error() == "sql: no rows in result set" {
-			appErr := &domain.BackendError{Msg: "Member Not Found"}
-			return nil, xerrors.Errorf("MysqlMemberRepository.Find: %w", appErr)
+			ErrBackend := &domain.BackendError{Msg: "Member Not Found"}
+			return nil, xerrors.Errorf("MysqlMemberRepository.Find: %w", ErrBackend)
 		}
 
-		appErr := &domain.BackendError{Msg: "rows.Scan Error", Err: ErrQuery}
-		return nil, xerrors.Errorf("MysqlMemberRepository.Find: %w", appErr)
+		ErrBackend := &domain.BackendError{Msg: "rows.Scan Error", Err: ErrQuery}
+		return nil, xerrors.Errorf("MysqlMemberRepository.Find: %w", ErrBackend)
 	}
 
 	me := &Openapi.Member{
@@ -103,8 +103,8 @@ func (m *MysqlMemberRepository) FindAll() (domain.Members, error) {
 
 	stmt, ErrPrepare := m.Db.Prepare(sql)
 	if ErrPrepare != nil {
-		appErr := &domain.BackendError{Msg: "Db.Prepare Error", Err: ErrPrepare}
-		return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", appErr)
+		ErrBackend := &domain.BackendError{Msg: "Db.Prepare Error", Err: ErrPrepare}
+		return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", ErrBackend)
 	}
 
 	defer func() {
@@ -117,8 +117,8 @@ func (m *MysqlMemberRepository) FindAll() (domain.Members, error) {
 	rows, ErrQuery := stmt.Query()
 
 	if ErrQuery != nil {
-		appErr := &domain.BackendError{Msg: "stmt.Query Error", Err: ErrQuery}
-		return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", appErr)
+		ErrBackend := &domain.BackendError{Msg: "stmt.Query Error", Err: ErrQuery}
+		return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", ErrBackend)
 	}
 
 	var tableData FindAllTableData
@@ -136,15 +136,15 @@ func (m *MysqlMemberRepository) FindAll() (domain.Members, error) {
 		)
 
 		if ErrRowsScan != nil {
-			appErr := &domain.BackendError{Msg: "rows.Scan Error", Err: ErrRowsScan}
-			return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", appErr)
+			ErrBackend := &domain.BackendError{Msg: "rows.Scan Error", Err: ErrRowsScan}
+			return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", ErrBackend)
 		}
 	}
 
 	// この条件の時はデータが1件も存在しない
 	if tableData.Id == 0 {
-		appErr := &domain.BackendError{Msg: "Members Not Found"}
-		return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", appErr)
+		ErrBackend := &domain.BackendError{Msg: "Members Not Found"}
+		return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", ErrBackend)
 	}
 
 	return ms, nil

--- a/infrastructure/repository/mysql_member_repository.go
+++ b/infrastructure/repository/mysql_member_repository.go
@@ -41,7 +41,7 @@ func (m *MysqlMemberRepository) Find(id int) (*Openapi.Member, error) {
 	stmt, ErrPrepare := m.Db.Prepare(query)
 
 	if ErrPrepare != nil {
-		ErrBackend := &domain.BackendError{Msg: "Db.Prepare Error", Err: ErrPrepare}
+		ErrBackend := &domain.BackendError{Message: "Db.Prepare Error", Err: ErrPrepare}
 		return nil, xerrors.Errorf("MysqlMemberRepository.Find: %w", ErrBackend)
 	}
 
@@ -58,11 +58,11 @@ func (m *MysqlMemberRepository) Find(id int) (*Openapi.Member, error) {
 	if ErrQuery != nil {
 		// この条件の時はデータが1件も存在しない
 		if ErrQuery.Error() == "sql: no rows in result set" {
-			ErrBackend := &domain.BackendError{Msg: "Member Not Found"}
+			ErrBackend := &domain.BackendError{Message: "Member Not Found"}
 			return nil, xerrors.Errorf("MysqlMemberRepository.Find: %w", ErrBackend)
 		}
 
-		ErrBackend := &domain.BackendError{Msg: "rows.Scan Error", Err: ErrQuery}
+		ErrBackend := &domain.BackendError{Message: "rows.Scan Error", Err: ErrQuery}
 		return nil, xerrors.Errorf("MysqlMemberRepository.Find: %w", ErrBackend)
 	}
 
@@ -103,7 +103,7 @@ func (m *MysqlMemberRepository) FindAll() (domain.Members, error) {
 
 	stmt, ErrPrepare := m.Db.Prepare(query)
 	if ErrPrepare != nil {
-		ErrBackend := &domain.BackendError{Msg: "Db.Prepare Error", Err: ErrPrepare}
+		ErrBackend := &domain.BackendError{Message: "Db.Prepare Error", Err: ErrPrepare}
 		return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", ErrBackend)
 	}
 
@@ -117,7 +117,7 @@ func (m *MysqlMemberRepository) FindAll() (domain.Members, error) {
 	rows, ErrQuery := stmt.Query()
 
 	if ErrQuery != nil {
-		ErrBackend := &domain.BackendError{Msg: "stmt.Query Error", Err: ErrQuery}
+		ErrBackend := &domain.BackendError{Message: "stmt.Query Error", Err: ErrQuery}
 		return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", ErrBackend)
 	}
 
@@ -136,14 +136,14 @@ func (m *MysqlMemberRepository) FindAll() (domain.Members, error) {
 		)
 
 		if ErrRowsScan != nil {
-			ErrBackend := &domain.BackendError{Msg: "rows.Scan Error", Err: ErrRowsScan}
+			ErrBackend := &domain.BackendError{Message: "rows.Scan Error", Err: ErrRowsScan}
 			return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", ErrBackend)
 		}
 	}
 
 	// この条件の時はデータが1件も存在しない
 	if tableData.Id == 0 {
-		ErrBackend := &domain.BackendError{Msg: "Members Not Found"}
+		ErrBackend := &domain.BackendError{Message: "Members Not Found"}
 		return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", ErrBackend)
 	}
 

--- a/infrastructure/repository/mysql_web_service_repository.go
+++ b/infrastructure/repository/mysql_web_service_repository.go
@@ -32,30 +32,30 @@ func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 		ASC
 	`
 
-	stmt, err := m.Db.Prepare(sql)
-	if err != nil {
-		appErr := &domain.BackendError{Msg: "Db.Prepare Error", Err: err}
+	stmt, ErrPrepare := m.Db.Prepare(sql)
+	if ErrPrepare != nil {
+		appErr := &domain.BackendError{Msg: "Db.Prepare Error", Err: ErrPrepare}
 		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", appErr)
 	}
 
 	defer func() {
-		err := stmt.Close()
-		if err != nil {
-			log.Fatal(err, "stmt.Close() Fatal.")
+		ErrStmtClose := stmt.Close()
+		if ErrStmtClose != nil {
+			log.Fatal(ErrStmtClose, "stmt.Close() Fatal.")
 		}
 	}()
 
-	rows, err := stmt.Query()
+	rows, ErrQuery := stmt.Query()
 
-	if err != nil {
-		appErr := &domain.BackendError{Msg: "stmt.Query Error", Err: err}
+	if ErrQuery != nil {
+		appErr := &domain.BackendError{Msg: "stmt.Query Error", Err: ErrQuery}
 		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", appErr)
 	}
 
 	var tableData WebServiceFindAllTableData
 	var ws domain.WebServices
 	for rows.Next() {
-		err := rows.Scan(&tableData.Id, &tableData.Url, &tableData.Description)
+		ErrRowsScan := rows.Scan(&tableData.Id, &tableData.Url, &tableData.Description)
 		ws = append(
 			ws,
 			&Openapi.WebService{
@@ -65,8 +65,8 @@ func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 			},
 		)
 
-		if err != nil {
-			appErr := &domain.BackendError{Msg: "rows.Scan Error", Err: err}
+		if ErrRowsScan != nil {
+			appErr := &domain.BackendError{Msg: "rows.Scan Error", Err: ErrRowsScan}
 			return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", appErr)
 		}
 	}

--- a/infrastructure/repository/mysql_web_service_repository.go
+++ b/infrastructure/repository/mysql_web_service_repository.go
@@ -34,8 +34,8 @@ func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 
 	stmt, ErrPrepare := m.Db.Prepare(sql)
 	if ErrPrepare != nil {
-		appErr := &domain.BackendError{Msg: "Db.Prepare Error", Err: ErrPrepare}
-		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", appErr)
+		ErrBackend := &domain.BackendError{Msg: "Db.Prepare Error", Err: ErrPrepare}
+		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", ErrBackend)
 	}
 
 	defer func() {
@@ -48,8 +48,8 @@ func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 	rows, ErrQuery := stmt.Query()
 
 	if ErrQuery != nil {
-		appErr := &domain.BackendError{Msg: "stmt.Query Error", Err: ErrQuery}
-		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", appErr)
+		ErrBackend := &domain.BackendError{Msg: "stmt.Query Error", Err: ErrQuery}
+		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", ErrBackend)
 	}
 
 	var tableData WebServiceFindAllTableData
@@ -66,15 +66,15 @@ func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 		)
 
 		if ErrRowsScan != nil {
-			appErr := &domain.BackendError{Msg: "rows.Scan Error", Err: ErrRowsScan}
-			return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", appErr)
+			ErrBackend := &domain.BackendError{Msg: "rows.Scan Error", Err: ErrRowsScan}
+			return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", ErrBackend)
 		}
 	}
 
 	// この条件の時はデータが1件も存在しない
 	if tableData.Id == 0 {
-		appErr := &domain.BackendError{Msg: "WebServices Not Found"}
-		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", appErr)
+		ErrBackend := &domain.BackendError{Msg: "WebServices Not Found"}
+		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", ErrBackend)
 	}
 
 	return ws, nil

--- a/infrastructure/repository/mysql_web_service_repository.go
+++ b/infrastructure/repository/mysql_web_service_repository.go
@@ -20,7 +20,7 @@ type WebServiceFindAllTableData struct {
 }
 
 func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
-	sql := `
+	query := `
 		SELECT
 		  id,
 		  url,
@@ -32,7 +32,7 @@ func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 		ASC
 	`
 
-	stmt, ErrPrepare := m.Db.Prepare(sql)
+	stmt, ErrPrepare := m.Db.Prepare(query)
 	if ErrPrepare != nil {
 		ErrBackend := &domain.BackendError{Msg: "Db.Prepare Error", Err: ErrPrepare}
 		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", ErrBackend)
@@ -53,11 +53,11 @@ func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 	}
 
 	var tableData WebServiceFindAllTableData
-	var ws domain.WebServices
+	var webServices domain.WebServices
 	for rows.Next() {
 		ErrRowsScan := rows.Scan(&tableData.Id, &tableData.Url, &tableData.Description)
-		ws = append(
-			ws,
+		webServices = append(
+			webServices,
 			&Openapi.WebService{
 				Id:          tableData.Id,
 				Url:         tableData.Url,
@@ -77,5 +77,5 @@ func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", ErrBackend)
 	}
 
-	return ws, nil
+	return webServices, nil
 }

--- a/infrastructure/repository/mysql_web_service_repository.go
+++ b/infrastructure/repository/mysql_web_service_repository.go
@@ -34,7 +34,7 @@ func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 
 	stmt, ErrPrepare := m.Db.Prepare(query)
 	if ErrPrepare != nil {
-		ErrBackend := &domain.BackendError{Msg: "Db.Prepare Error", Err: ErrPrepare}
+		ErrBackend := &domain.BackendError{Message: "Db.Prepare Error", Err: ErrPrepare}
 		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", ErrBackend)
 	}
 
@@ -48,7 +48,7 @@ func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 	rows, ErrQuery := stmt.Query()
 
 	if ErrQuery != nil {
-		ErrBackend := &domain.BackendError{Msg: "stmt.Query Error", Err: ErrQuery}
+		ErrBackend := &domain.BackendError{Message: "stmt.Query Error", Err: ErrQuery}
 		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", ErrBackend)
 	}
 
@@ -66,14 +66,14 @@ func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 		)
 
 		if ErrRowsScan != nil {
-			ErrBackend := &domain.BackendError{Msg: "rows.Scan Error", Err: ErrRowsScan}
+			ErrBackend := &domain.BackendError{Message: "rows.Scan Error", Err: ErrRowsScan}
 			return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", ErrBackend)
 		}
 	}
 
 	// この条件の時はデータが1件も存在しない
 	if tableData.Id == 0 {
-		ErrBackend := &domain.BackendError{Msg: "WebServices Not Found"}
+		ErrBackend := &domain.BackendError{Message: "WebServices Not Found"}
 		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", ErrBackend)
 	}
 

--- a/test/db_creator.go
+++ b/test/db_creator.go
@@ -9,7 +9,7 @@ import (
 
 type DbCreator struct{}
 
-func (d *DbCreator) Create(t *testing.T) *sql.DB {
+func (c *DbCreator) Create(t *testing.T) *sql.DB {
 	db, err := sql.Open("mysql", config.GetTestDsn())
 
 	if err != nil {

--- a/test/seeder.go
+++ b/test/seeder.go
@@ -55,9 +55,9 @@ func (s *Seeder) TruncateAllTable() error {
 
 	_, ErrSetForeignKeyFalse := tx.Exec("SET FOREIGN_KEY_CHECKS=0")
 	if ErrSetForeignKeyFalse != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			log.Fatal(rollbackErr, "Transaction.Rollback() Fatal.")
+		ErrRollback := tx.Rollback()
+		if ErrRollback != nil {
+			log.Fatal(ErrRollback, "Transaction.Rollback() Fatal.")
 		}
 		return ErrSetForeignKeyFalse
 	}
@@ -65,36 +65,36 @@ func (s *Seeder) TruncateAllTable() error {
 	// TODO テーブル分ループさせるように改修を行う
 	_, ErrTruncateMembers := tx.Exec("TRUNCATE members")
 	if ErrTruncateMembers != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			log.Fatal(rollbackErr, "Transaction.Rollback() Fatal.")
+		ErrRollback := tx.Rollback()
+		if ErrRollback != nil {
+			log.Fatal(ErrRollback, "Transaction.Rollback() Fatal.")
 		}
 		return ErrTruncateMembers
 	}
 
 	_, ErrTruncateGitHubUsers := tx.Exec("TRUNCATE members_github_users")
 	if ErrTruncateGitHubUsers != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			log.Fatal(rollbackErr, "Transaction.Rollback() Fatal.")
+		ErrRollback := tx.Rollback()
+		if ErrRollback != nil {
+			log.Fatal(ErrRollback, "Transaction.Rollback() Fatal.")
 		}
 		return ErrTruncateGitHubUsers
 	}
 
 	_, ErrTruncateWebServices := tx.Exec("TRUNCATE webservices")
 	if ErrTruncateWebServices != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			log.Fatal(rollbackErr, "Transaction.Rollback() Fatal.")
+		ErrRollback := tx.Rollback()
+		if ErrRollback != nil {
+			log.Fatal(ErrRollback, "Transaction.Rollback() Fatal.")
 		}
 		return ErrTruncateWebServices
 	}
 
 	_, ErrSetForeignKeyTrue := tx.Exec("SET FOREIGN_KEY_CHECKS=1")
 	if ErrSetForeignKeyTrue != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			log.Fatal(rollbackErr, "Transaction.Rollback() Fatal.")
+		ErrRollback := tx.Rollback()
+		if ErrRollback != nil {
+			log.Fatal(ErrRollback, "Transaction.Rollback() Fatal.")
 		}
 		return ErrSetForeignKeyTrue
 	}

--- a/test/seeder.go
+++ b/test/seeder.go
@@ -105,12 +105,12 @@ func (s *Seeder) TruncateAllTable() error {
 func (s *Seeder) loadDataFromCsv(tx *sql.Tx, table, filePath string) (sql.Result, error) {
 	q := `
 		LOAD DATA
-			LOCAL INFILE "%s"
+			LOCAL INFILE '%s'
 		INTO TABLE %s
 		FIELDS
-			TERMINATED BY ","
+			TERMINATED BY ','
 		LINES
-			TERMINATED BY "\n"
+			TERMINATED BY '\n'
 			IGNORE 1 LINES
 	`
 

--- a/test/seeder.go
+++ b/test/seeder.go
@@ -103,7 +103,7 @@ func (s *Seeder) TruncateAllTable() error {
 }
 
 func (s *Seeder) loadDataFromCsv(tx *sql.Tx, table, filePath string) (sql.Result, error) {
-	q := `
+	query := `
 		LOAD DATA
 			LOCAL INFILE '%s'
 		INTO TABLE %s
@@ -116,5 +116,5 @@ func (s *Seeder) loadDataFromCsv(tx *sql.Tx, table, filePath string) (sql.Result
 
 	mysql.RegisterLocalFile(filePath)
 
-	return tx.Exec(fmt.Sprintf(q, filePath, table))
+	return tx.Exec(fmt.Sprintf(query, filePath, table))
 }

--- a/test/seeder.go
+++ b/test/seeder.go
@@ -103,18 +103,18 @@ func (s *Seeder) TruncateAllTable() error {
 }
 
 func (s *Seeder) loadDataFromCsv(tx *sql.Tx, table, filePath string) (sql.Result, error) {
-	sql := `
+	q := `
 		LOAD DATA
-			LOCAL INFILE '%s'
+			LOCAL INFILE "%s"
 		INTO TABLE %s
 		FIELDS
-			TERMINATED BY ','
+			TERMINATED BY ","
 		LINES
-			TERMINATED BY '\n'
+			TERMINATED BY "\n"
 			IGNORE 1 LINES
 	`
 
 	mysql.RegisterLocalFile(filePath)
 
-	return tx.Exec(fmt.Sprintf(sql, filePath, table))
+	return tx.Exec(fmt.Sprintf(q, filePath, table))
 }

--- a/test/seeder.go
+++ b/test/seeder.go
@@ -35,7 +35,7 @@ func (s *Seeder) Execute() error {
 		table := file.Name()[:len(file.Name())-len(ext)]
 		csvFilePath := filepath.Join(s.DirPath, file.Name())
 
-		if _, ErrLoadData := loadDataFromCSV(tx, table, csvFilePath); ErrLoadData != nil {
+		if _, ErrLoadData := s.loadDataFromCsv(tx, table, csvFilePath); ErrLoadData != nil {
 			ErrRollback := tx.Rollback()
 			if ErrRollback != nil {
 				log.Fatal(ErrRollback, "Transaction.Rollback() Fatal.")
@@ -102,8 +102,8 @@ func (s *Seeder) TruncateAllTable() error {
 	return tx.Commit()
 }
 
-func loadDataFromCSV(tx *sql.Tx, table, filePath string) (sql.Result, error) {
-	s := `
+func (s *Seeder) loadDataFromCsv(tx *sql.Tx, table, filePath string) (sql.Result, error) {
+	sql := `
 		LOAD DATA
 			LOCAL INFILE '%s'
 		INTO TABLE %s
@@ -116,5 +116,5 @@ func loadDataFromCSV(tx *sql.Tx, table, filePath string) (sql.Result, error) {
 
 	mysql.RegisterLocalFile(filePath)
 
-	return tx.Exec(fmt.Sprintf(s, filePath, table))
+	return tx.Exec(fmt.Sprintf(sql, filePath, table))
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/portfolio-backend/issues/56

# Doneの定義
- https://github.com/nekochans/portfolio-backend/issues/56 の完了の定義を満たしている事

# 変更点概要

変数名をGoの慣例に合わせて修正、詳細は下記の通り。

- レシーバや引数は1文字の変数に修正出来る箇所は修正
- package名と同様の変数名は避けるように修正
- 無理な略語を使っている変数名は普通の英単語に修正


## 修正方針

- 1文字の変数はスコープが小さい事前提。（例）1文字のグローバル変数も使わない

- 構造体のフィールド名等にも1文字は使わない

- 略語を無理して考えるくらいなら、普通に英単語を使う

- 1文字の変数名が使えないなら、普通に英単語を使う