### PR TITLE
log.Fatal()を利用している箇所をエラーを返すように修正

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -22,6 +22,11 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Docker set up
         run: |
           cp .air.normal.conf .air.conf

--- a/application/member_scenario_test.go
+++ b/application/member_scenario_test.go
@@ -66,7 +66,11 @@ func fixtureTestMemberScenarioFetchAllFromMysqlFailureMembersNotFound(t *testing
 
 func TestMemberScenarioFetchFromMysqlSucceed(t *testing.T) {
 	dbCreator := &test.DbCreator{}
-	db := dbCreator.Create(t)
+	db, ErrTestDbConnect := dbCreator.Create()
+	if ErrTestDbConnect != nil {
+		t.Fatal("Test DB Connect Error", ErrTestDbConnect)
+	}
+
 	fixtureTestMemberScenarioFetchFromMysqlSucceed(t, db)
 
 	expected := &Openapi.Member{
@@ -93,7 +97,10 @@ func TestMemberScenarioFetchFromMysqlSucceed(t *testing.T) {
 
 func TestMemberScenarioFetchFromMysqlFailureMemberNotFound(t *testing.T) {
 	dbCreator := &test.DbCreator{}
-	db := dbCreator.Create(t)
+	db, ErrTestDbConnect := dbCreator.Create()
+	if ErrTestDbConnect != nil {
+		t.Fatal("Test DB Connect Error", ErrTestDbConnect)
+	}
 	fixtureTestMemberScenarioFetchFromMysqlFailureMembersNotFound(t, db)
 
 	repo := &repository.MysqlMemberRepository{Db: db}
@@ -149,7 +156,10 @@ func TestMemberScenarioFetchAllMemorySucceed(t *testing.T) {
 
 func TestMemberScenarioFetchAllFromMysqlSucceed(t *testing.T) {
 	dbCreator := &test.DbCreator{}
-	db := dbCreator.Create(t)
+	db, ErrTestDbConnect := dbCreator.Create()
+	if ErrTestDbConnect != nil {
+		t.Fatal("Test DB Connect Error", ErrTestDbConnect)
+	}
 	fixtureTestMemberScenarioFetchAllFromMysqlSucceed(t, db)
 
 	repo := &repository.MysqlMemberRepository{Db: db}
@@ -187,7 +197,10 @@ func TestMemberScenarioFetchAllFromMysqlSucceed(t *testing.T) {
 
 func TestMemberScenarioFetchAllFromMysqlFailureMembersNotFound(t *testing.T) {
 	dbCreator := &test.DbCreator{}
-	db := dbCreator.Create(t)
+	db, ErrTestDbConnect := dbCreator.Create()
+	if ErrTestDbConnect != nil {
+		t.Fatal("Test DB Connect Error", ErrTestDbConnect)
+	}
 	fixtureTestMemberScenarioFetchAllFromMysqlFailureMembersNotFound(t, db)
 
 	repo := &repository.MysqlMemberRepository{Db: db}

--- a/application/web_service_scenario_test.go
+++ b/application/web_service_scenario_test.go
@@ -62,7 +62,10 @@ func fixtureTestWebServiceScenarioFetchAllFromMysqlFailureWebServicesNotFound(t 
 
 func TestWebServiceScenarioFetchAllFromMysqlSucceed(t *testing.T) {
 	dbCreator := &test.DbCreator{}
-	db := dbCreator.Create(t)
+	db, ErrTestDbConnect := dbCreator.Create()
+	if ErrTestDbConnect != nil {
+		t.Fatal("Test DB Connect Error", ErrTestDbConnect)
+	}
 	fixtureTestWebServiceScenarioFetchAllFromMysqlSucceed(t, db)
 
 	repo := &repository.MysqlWebServiceRepository{Db: db}
@@ -93,7 +96,10 @@ func TestWebServiceScenarioFetchAllFromMysqlSucceed(t *testing.T) {
 
 func TestWebServiceScenarioFetchAllFromMysqlFailureWebServicesNotFound(t *testing.T) {
 	dbCreator := &test.DbCreator{}
-	db := dbCreator.Create(t)
+	db, ErrTestDbConnect := dbCreator.Create()
+	if ErrTestDbConnect != nil {
+		t.Fatal("Test DB Connect Error", ErrTestDbConnect)
+	}
 	fixtureTestWebServiceScenarioFetchAllFromMysqlFailureWebServicesNotFound(t, db)
 
 	repo := &repository.MysqlWebServiceRepository{Db: db}

--- a/infrastructure/http_response.go
+++ b/infrastructure/http_response.go
@@ -9,7 +9,7 @@ import (
 )
 
 func CreateJsonResponse(w http.ResponseWriter, r *http.Request, status int, payload interface{}) error {
-	res, ErrJsonEncode := json.MarshalIndent(payload, "", "    ")
+	res, ErrJsonEncode := json.Marshal(payload)
 	if ErrJsonEncode != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, ErrWriteResponse := w.Write([]byte(ErrJsonEncode.Error()))

--- a/infrastructure/http_server.go
+++ b/infrastructure/http_server.go
@@ -37,6 +37,8 @@ func (s *HttpServer) GetMembers(w http.ResponseWriter, r *http.Request) {
 			ErrCreateErrorResponse := xerrors.Errorf("Failed to create error response: %w", ErrCreateError)
 			s.Logger.Error(ErrCreateError.Error(), zap.Error(ErrCreateErrorResponse))
 		}
+
+		return
 	}
 
 	ErrCreateJson := CreateJsonResponse(w, r, http.StatusOK, members)
@@ -58,6 +60,7 @@ func (s *HttpServer) GetMemberById(w http.ResponseWriter, r *http.Request, id in
 			ErrCreateErrorResponse := xerrors.Errorf("Failed to create error response: %w", ErrCreateError)
 			s.Logger.Error(ErrCreateError.Error(), zap.Error(ErrCreateErrorResponse))
 		}
+		return
 	}
 
 	ErrCreateJson := CreateJsonResponse(w, r, http.StatusOK, member)
@@ -79,6 +82,7 @@ func (s *HttpServer) GetWebservices(w http.ResponseWriter, r *http.Request) {
 			ErrCreateErrorResponse := xerrors.Errorf("Failed to create error response: %w", ErrCreateError)
 			s.Logger.Error(ErrCreateError.Error(), zap.Error(ErrCreateErrorResponse))
 		}
+		return
 	}
 
 	ErrCreateJson := CreateJsonResponse(w, r, http.StatusOK, res)

--- a/infrastructure/http_server.go
+++ b/infrastructure/http_server.go
@@ -26,7 +26,7 @@ type HttpServer struct {
 }
 
 func (s *HttpServer) GetMembers(w http.ResponseWriter, r *http.Request) {
-	repo := &repository.MysqlMemberRepository{Db: s.Db}
+	repo := &repository.MysqlMemberRepository{Db: s.Db, Logger: s.Logger}
 
 	scenario := application.MemberScenario{MemberRepository: repo}
 	members, ErrFetchAll := scenario.FetchAllFromMysql()
@@ -49,7 +49,7 @@ func (s *HttpServer) GetMembers(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *HttpServer) GetMemberById(w http.ResponseWriter, r *http.Request, id int) {
-	repo := &repository.MysqlMemberRepository{Db: s.Db}
+	repo := &repository.MysqlMemberRepository{Db: s.Db, Logger: s.Logger}
 	scenario := application.MemberScenario{MemberRepository: repo}
 
 	req := &application.MemberFetchRequest{Id: id}
@@ -71,7 +71,7 @@ func (s *HttpServer) GetMemberById(w http.ResponseWriter, r *http.Request, id in
 }
 
 func (s *HttpServer) GetWebservices(w http.ResponseWriter, r *http.Request) {
-	repo := &repository.MysqlWebServiceRepository{Db: s.Db}
+	repo := &repository.MysqlWebServiceRepository{Db: s.Db, Logger: s.Logger}
 
 	scenario := &application.WebServiceScenario{WebServiceRepository: repo}
 

--- a/infrastructure/http_server.go
+++ b/infrastructure/http_server.go
@@ -29,10 +29,10 @@ func (s *HttpServer) GetMembers(w http.ResponseWriter, r *http.Request) {
 	repo := &repository.MysqlMemberRepository{Db: s.Db}
 
 	scenario := application.MemberScenario{MemberRepository: repo}
-	members, err := scenario.FetchAllFromMysql()
+	members, ErrFetchAll := scenario.FetchAllFromMysql()
 
-	if err != nil {
-		ErrCreateError := CreateErrorResponse(w, r, err)
+	if ErrFetchAll != nil {
+		ErrCreateError := CreateErrorResponse(w, r, ErrFetchAll)
 		if ErrCreateError != nil {
 			ErrCreateErrorResponse := xerrors.Errorf("Failed to create error response: %w", ErrCreateError)
 			s.Logger.Error(ErrCreateError.Error(), zap.Error(ErrCreateErrorResponse))
@@ -51,9 +51,9 @@ func (s *HttpServer) GetMemberById(w http.ResponseWriter, r *http.Request, id in
 	scenario := application.MemberScenario{MemberRepository: repo}
 
 	req := &application.MemberFetchRequest{Id: id}
-	member, err := scenario.FetchFromMysql(*req)
-	if err != nil {
-		ErrCreateError := CreateErrorResponse(w, r, err)
+	member, ErrFetch := scenario.FetchFromMysql(*req)
+	if ErrFetch != nil {
+		ErrCreateError := CreateErrorResponse(w, r, ErrFetch)
 		if ErrCreateError != nil {
 			ErrCreateErrorResponse := xerrors.Errorf("Failed to create error response: %w", ErrCreateError)
 			s.Logger.Error(ErrCreateError.Error(), zap.Error(ErrCreateErrorResponse))
@@ -72,9 +72,9 @@ func (s *HttpServer) GetWebservices(w http.ResponseWriter, r *http.Request) {
 
 	scenario := &application.WebServiceScenario{WebServiceRepository: repo}
 
-	res, err := scenario.FetchAllFromMysql()
-	if err != nil {
-		ErrCreateError := CreateErrorResponse(w, r, err)
+	res, ErrFetchAll := scenario.FetchAllFromMysql()
+	if ErrFetchAll != nil {
+		ErrCreateError := CreateErrorResponse(w, r, ErrFetchAll)
 		if ErrCreateError != nil {
 			ErrCreateErrorResponse := xerrors.Errorf("Failed to create error response: %w", ErrCreateError)
 			s.Logger.Error(ErrCreateError.Error(), zap.Error(ErrCreateErrorResponse))

--- a/infrastructure/http_server.go
+++ b/infrastructure/http_server.go
@@ -32,11 +32,18 @@ func (s *HttpServer) GetMembers(w http.ResponseWriter, r *http.Request) {
 	members, err := scenario.FetchAllFromMysql()
 
 	if err != nil {
-		CreateErrorResponse(w, r, err)
-		return
+		ErrCreateError := CreateErrorResponse(w, r, err)
+		if ErrCreateError != nil {
+			ErrCreateErrorResponse := xerrors.Errorf("Failed to create error response: %w", ErrCreateError)
+			s.Logger.Error(ErrCreateError.Error(), zap.Error(ErrCreateErrorResponse))
+		}
 	}
 
-	CreateJsonResponse(w, r, http.StatusOK, members)
+	ErrCreateJson := CreateJsonResponse(w, r, http.StatusOK, members)
+	if ErrCreateJson != nil {
+		ErrCreateJsonResponse := xerrors.Errorf("Failed to create json response: %w", ErrCreateJson)
+		s.Logger.Error(ErrCreateJson.Error(), zap.Error(ErrCreateJsonResponse))
+	}
 }
 
 func (s *HttpServer) GetMemberById(w http.ResponseWriter, r *http.Request, id int) {
@@ -46,11 +53,18 @@ func (s *HttpServer) GetMemberById(w http.ResponseWriter, r *http.Request, id in
 	req := &application.MemberFetchRequest{Id: id}
 	member, err := scenario.FetchFromMysql(*req)
 	if err != nil {
-		CreateErrorResponse(w, r, err)
-		return
+		ErrCreateError := CreateErrorResponse(w, r, err)
+		if ErrCreateError != nil {
+			ErrCreateErrorResponse := xerrors.Errorf("Failed to create error response: %w", ErrCreateError)
+			s.Logger.Error(ErrCreateError.Error(), zap.Error(ErrCreateErrorResponse))
+		}
 	}
 
-	CreateJsonResponse(w, r, http.StatusOK, member)
+	ErrCreateJson := CreateJsonResponse(w, r, http.StatusOK, member)
+	if ErrCreateJson != nil {
+		ErrCreateJsonResponse := xerrors.Errorf("Failed to create json response: %w", ErrCreateJson)
+		s.Logger.Error(ErrCreateJson.Error(), zap.Error(ErrCreateJsonResponse))
+	}
 }
 
 func (s *HttpServer) GetWebservices(w http.ResponseWriter, r *http.Request) {
@@ -60,11 +74,18 @@ func (s *HttpServer) GetWebservices(w http.ResponseWriter, r *http.Request) {
 
 	res, err := scenario.FetchAllFromMysql()
 	if err != nil {
-		CreateErrorResponse(w, r, err)
-		return
+		ErrCreateError := CreateErrorResponse(w, r, err)
+		if ErrCreateError != nil {
+			ErrCreateErrorResponse := xerrors.Errorf("Failed to create error response: %w", ErrCreateError)
+			s.Logger.Error(ErrCreateError.Error(), zap.Error(ErrCreateErrorResponse))
+		}
 	}
 
-	CreateJsonResponse(w, r, http.StatusOK, res)
+	ErrCreateJson := CreateJsonResponse(w, r, http.StatusOK, res)
+	if ErrCreateJson != nil {
+		ErrCreateJsonResponse := xerrors.Errorf("Failed to create json response: %w", ErrCreateJson)
+		s.Logger.Error(ErrCreateJson.Error(), zap.Error(ErrCreateJsonResponse))
+	}
 }
 
 func (s *HttpServer) middleware() {

--- a/infrastructure/repository/mysql_member_repository.go
+++ b/infrastructure/repository/mysql_member_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"database/sql"
+
 	"go.uber.org/zap"
 
 	_ "github.com/go-sql-driver/mysql"

--- a/infrastructure/repository/mysql_member_repository.go
+++ b/infrastructure/repository/mysql_member_repository.go
@@ -2,8 +2,6 @@ package repository
 
 import (
 	"database/sql"
-	"log"
-
 	"go.uber.org/zap"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -113,7 +111,7 @@ func (r *MysqlMemberRepository) FindAll() (domain.Members, error) {
 	defer func() {
 		ErrStmtClose := stmt.Close()
 		if ErrStmtClose != nil {
-			log.Fatal(ErrStmtClose, "stmt.Close() Fatal.")
+			r.Logger.Error("stmt.Close() Fatal.", zap.Error(ErrStmtClose))
 		}
 	}()
 

--- a/infrastructure/repository/mysql_member_repository.go
+++ b/infrastructure/repository/mysql_member_repository.go
@@ -21,7 +21,7 @@ type FindTableData struct {
 	CvRepoName string
 }
 
-func (m *MysqlMemberRepository) Find(id int) (*Openapi.Member, error) {
+func (r *MysqlMemberRepository) Find(id int) (*Openapi.Member, error) {
 	query := `
 		SELECT
 		  m.id AS Id,
@@ -38,7 +38,7 @@ func (m *MysqlMemberRepository) Find(id int) (*Openapi.Member, error) {
 			m.id = ?
 	`
 
-	stmt, ErrPrepare := m.Db.Prepare(query)
+	stmt, ErrPrepare := r.Db.Prepare(query)
 
 	if ErrPrepare != nil {
 		ErrBackend := &domain.BackendError{Message: "Db.Prepare Error", Err: ErrPrepare}
@@ -83,7 +83,7 @@ type FindAllTableData struct {
 	CvRepoName string
 }
 
-func (m *MysqlMemberRepository) FindAll() (domain.Members, error) {
+func (r *MysqlMemberRepository) FindAll() (domain.Members, error) {
 	query := `
 		SELECT
 		  m.id AS Id,
@@ -101,7 +101,7 @@ func (m *MysqlMemberRepository) FindAll() (domain.Members, error) {
 		ASC
 	`
 
-	stmt, ErrPrepare := m.Db.Prepare(query)
+	stmt, ErrPrepare := r.Db.Prepare(query)
 	if ErrPrepare != nil {
 		ErrBackend := &domain.BackendError{Message: "Db.Prepare Error", Err: ErrPrepare}
 		return nil, xerrors.Errorf("MysqlMemberRepository.FindAll: %w", ErrBackend)

--- a/infrastructure/repository/mysql_member_repository.go
+++ b/infrastructure/repository/mysql_member_repository.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"log"
 
+	"go.uber.org/zap"
+
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/nekochans/portfolio-backend/domain"
 	Openapi "github.com/nekochans/portfolio-backend/openapi"
@@ -11,7 +13,8 @@ import (
 )
 
 type MysqlMemberRepository struct {
-	Db *sql.DB
+	Db     *sql.DB
+	Logger *zap.Logger
 }
 
 type FindTableData struct {
@@ -46,9 +49,9 @@ func (r *MysqlMemberRepository) Find(id int) (*Openapi.Member, error) {
 	}
 
 	defer func() {
-		err := stmt.Close()
-		if err != nil {
-			log.Fatal(err, "stmt.Close() Fatal.")
+		ErrStmtClose := stmt.Close()
+		if ErrStmtClose != nil {
+			r.Logger.Error("stmt.Close() Fatal.", zap.Error(ErrStmtClose))
 		}
 	}()
 

--- a/infrastructure/repository/mysql_web_service_repository.go
+++ b/infrastructure/repository/mysql_web_service_repository.go
@@ -19,7 +19,7 @@ type WebServiceFindAllTableData struct {
 	Description string
 }
 
-func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
+func (r *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 	query := `
 		SELECT
 		  id,
@@ -32,7 +32,7 @@ func (m *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 		ASC
 	`
 
-	stmt, ErrPrepare := m.Db.Prepare(query)
+	stmt, ErrPrepare := r.Db.Prepare(query)
 	if ErrPrepare != nil {
 		ErrBackend := &domain.BackendError{Message: "Db.Prepare Error", Err: ErrPrepare}
 		return nil, xerrors.Errorf("MysqlWebServiceRepository.FindAll: %w", ErrBackend)

--- a/infrastructure/repository/mysql_web_service_repository.go
+++ b/infrastructure/repository/mysql_web_service_repository.go
@@ -2,15 +2,16 @@ package repository
 
 import (
 	"database/sql"
-	"log"
 
 	"github.com/nekochans/portfolio-backend/domain"
 	Openapi "github.com/nekochans/portfolio-backend/openapi"
+	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 )
 
 type MysqlWebServiceRepository struct {
-	Db *sql.DB
+	Db     *sql.DB
+	Logger *zap.Logger
 }
 
 type WebServiceFindAllTableData struct {
@@ -41,7 +42,7 @@ func (r *MysqlWebServiceRepository) FindAll() (domain.WebServices, error) {
 	defer func() {
 		ErrStmtClose := stmt.Close()
 		if ErrStmtClose != nil {
-			log.Fatal(ErrStmtClose, "stmt.Close() Fatal.")
+			r.Logger.Error("stmt.Close() Fatal.", zap.Error(ErrStmtClose))
 		}
 	}()
 

--- a/test/db_creator.go
+++ b/test/db_creator.go
@@ -2,19 +2,17 @@ package test
 
 import (
 	"database/sql"
-	"testing"
-
 	"github.com/nekochans/portfolio-backend/config"
 )
 
 type DbCreator struct{}
 
-func (c *DbCreator) Create(t *testing.T) *sql.DB {
+func (c *DbCreator) Create() (*sql.DB, error) {
 	db, err := sql.Open("mysql", config.GetTestDsn())
 
 	if err != nil {
-		t.Fatal("Db Connect Error", err)
+		return nil, err
 	}
 
-	return db
+	return db, nil
 }

--- a/test/db_creator.go
+++ b/test/db_creator.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"database/sql"
+
 	"github.com/nekochans/portfolio-backend/config"
 )
 

--- a/test/seeder.go
+++ b/test/seeder.go
@@ -3,11 +3,11 @@ package test
 import (
 	"database/sql"
 	"fmt"
-	"golang.org/x/xerrors"
 	"io/ioutil"
 	"path/filepath"
 
 	"github.com/go-sql-driver/mysql"
+	"golang.org/x/xerrors"
 )
 
 type Seeder struct {

--- a/test/seeder.go
+++ b/test/seeder.go
@@ -3,8 +3,8 @@ package test
 import (
 	"database/sql"
 	"fmt"
+	"golang.org/x/xerrors"
 	"io/ioutil"
-	"log"
 	"path/filepath"
 
 	"github.com/go-sql-driver/mysql"
@@ -38,7 +38,7 @@ func (s *Seeder) Execute() error {
 		if _, ErrLoadData := s.loadDataFromCsv(tx, table, csvFilePath); ErrLoadData != nil {
 			ErrRollback := tx.Rollback()
 			if ErrRollback != nil {
-				log.Fatal(ErrRollback, "Transaction.Rollback() Fatal.")
+				return xerrors.Errorf("Transaction.Rollback() Fatal: %w", ErrRollback)
 			}
 			return ErrLoadData
 		}
@@ -57,7 +57,7 @@ func (s *Seeder) TruncateAllTable() error {
 	if ErrSetForeignKeyFalse != nil {
 		ErrRollback := tx.Rollback()
 		if ErrRollback != nil {
-			log.Fatal(ErrRollback, "Transaction.Rollback() Fatal.")
+			return xerrors.Errorf("Transaction.Rollback() Fatal: %w", ErrRollback)
 		}
 		return ErrSetForeignKeyFalse
 	}
@@ -67,7 +67,7 @@ func (s *Seeder) TruncateAllTable() error {
 	if ErrTruncateMembers != nil {
 		ErrRollback := tx.Rollback()
 		if ErrRollback != nil {
-			log.Fatal(ErrRollback, "Transaction.Rollback() Fatal.")
+			return xerrors.Errorf("Transaction.Rollback() Fatal: %w", ErrRollback)
 		}
 		return ErrTruncateMembers
 	}
@@ -76,7 +76,7 @@ func (s *Seeder) TruncateAllTable() error {
 	if ErrTruncateGitHubUsers != nil {
 		ErrRollback := tx.Rollback()
 		if ErrRollback != nil {
-			log.Fatal(ErrRollback, "Transaction.Rollback() Fatal.")
+			return xerrors.Errorf("Transaction.Rollback() Fatal: %w", ErrRollback)
 		}
 		return ErrTruncateGitHubUsers
 	}
@@ -85,7 +85,7 @@ func (s *Seeder) TruncateAllTable() error {
 	if ErrTruncateWebServices != nil {
 		ErrRollback := tx.Rollback()
 		if ErrRollback != nil {
-			log.Fatal(ErrRollback, "Transaction.Rollback() Fatal.")
+			return xerrors.Errorf("Transaction.Rollback() Fatal: %w", ErrRollback)
 		}
 		return ErrTruncateWebServices
 	}
@@ -94,7 +94,7 @@ func (s *Seeder) TruncateAllTable() error {
 	if ErrSetForeignKeyTrue != nil {
 		ErrRollback := tx.Rollback()
 		if ErrRollback != nil {
-			log.Fatal(ErrRollback, "Transaction.Rollback() Fatal.")
+			return xerrors.Errorf("Transaction.Rollback() Fatal: %w", ErrRollback)
 		}
 		return ErrSetForeignKeyTrue
 	}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/portfolio-backend/issues/60

# Doneの定義
- https://github.com/nekochans/portfolio-backend/issues/60 の完了の定義を満たしている事

# 変更点概要
`log.Fatal()` を利用している箇所をErrorを返すように修正。

今まで `log.Fatal()` を使っていた箇所では `zap` によるエラーログを出力するように変更してあります。

# 補足情報
PRの趣旨とは関係ないがDockerHubの匿名ユーザーPull制限に引っかかるとデプロイが出来なくなってしまうので、 `docker/login-action@v1` でDockerHubにログインを行うように変更。