### PR TITLE
Goのバージョンを1.17系に更新

### DIFF
--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine3.12 as build
+FROM golang:1.17-alpine3.13 as build
 
 LABEL maintainer="https://github.com/nekochans"
 
@@ -6,30 +6,28 @@ WORKDIR /go/app
 
 COPY . .
 
-ENV GO111MODULE=off
-
 ARG GOLANGCI_LINT_VERSION=v1.32.0
+ARG AIR_VERSION=v1.27.3
+ARG DLV_VERSION=v1.7.1
+ARG OAPI_CODEGEN_VERSION=v1.8.2
+ARG MIGRATE_VERSION=v4.14.1
 
 RUN set -eux && \
   apk update && \
   apk add --no-cache git curl make && \
-  go get -u github.com/cosmtrek/air && \
-  go build -o /go/bin/air github.com/cosmtrek/air && \
-  go get -u github.com/go-delve/delve/cmd/dlv && \
-  go build -o /go/bin/dlv github.com/go-delve/delve/cmd/dlv && \
-  go get -tags 'mysql' -u github.com/golang-migrate/migrate/cmd/migrate && \
+  go install github.com/cosmtrek/air@${AIR_VERSION} && \
+  go install github.com/go-delve/delve/cmd/dlv@${DLV_VERSION} && \
+  go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@${OAPI_CODEGEN_VERSION} && \
+  go install -tags 'mysql' github.com/golang-migrate/migrate/v4/cmd/migrate@${MIGRATE_VERSION} && \
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION} && \
-  go get github.com/deepmap/oapi-codegen/cmd/oapi-codegen && \
-  go get golang.org/x/tools/cmd/goimports
-
-ENV GO111MODULE on
+  go install golang.org/x/tools/cmd/goimports@latest
 
 RUN set -eux && \
   go build -o portfolio-backend ./cmd/rest/main.go
 
 ENV CGO_ENABLED 0
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 WORKDIR /app
 

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM mysql:5.7.32
 
 LABEL maintainer="https://github.com/nekochans"
 

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.17.9-alpine
+FROM nginx:1.21.3-alpine
 
 LABEL maintainer="https://github.com/nekochans"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nekochans/portfolio-backend
 
-go 1.15
+go 1.17
 
 require (
 	github.com/deepmap/oapi-codegen v1.3.13
@@ -9,4 +9,10 @@ require (
 	go.uber.org/zap v1.16.0
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
+)
+
+require (
+	github.com/pkg/errors v0.8.1 // indirect
+	go.uber.org/atomic v1.6.0 // indirect
+	go.uber.org/multierr v1.5.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -17,10 +17,8 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219/go.mod h1:/X8TswGSh1pIozq4ZwCfxS0WA5JGXguxk94ar/4c87Y=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
@@ -85,7 +83,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/portfolio-backend/issues/68

# Doneの定義
- https://github.com/nekochans/portfolio-backend/issues/68 の完了の定義を満たしている事

# 変更点概要

Go1.17に最適な状態になるようにDockerfileやgo.modを更新。

またDockerfile周りで以下の変更も行った。

- mysqlのコンテナはトラブルが多いのでversionを固定するように変更
- nginxを最新安定版に更新