### PR TITLE
エラーの設計をpkg/errorsを使った形に変更

### DIFF
--- a/domain/member_repository.go
+++ b/domain/member_repository.go
@@ -1,6 +1,14 @@
 package domain
 
-import Openapi "github.com/nekochans/portfolio-backend/openapi"
+import (
+	Openapi "github.com/nekochans/portfolio-backend/openapi"
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrMemberNotFound             = errors.New("member not found")
+	ErrMemberRepositoryUnexpected = errors.New("member repository unexpected error")
+)
 
 type MemberRepository interface {
 	Find(id int) (*Openapi.Member, error)

--- a/domain/web_service_repository.go
+++ b/domain/web_service_repository.go
@@ -1,5 +1,12 @@
 package domain
 
+import "github.com/pkg/errors"
+
+var (
+	ErrWebServiceNotFound             = errors.New("web service not found")
+	ErrWebServiceRepositoryUnexpected = errors.New("web service repository unexpected error")
+)
+
 type WebServiceRepository interface {
 	FindAll() (WebServices, error)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,12 @@ require (
 	github.com/deepmap/oapi-codegen v1.3.13
 	github.com/go-chi/chi v4.0.3+incompatible
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/pkg/errors v0.8.1
 	go.uber.org/zap v1.16.0
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )
 
 require (
-	github.com/pkg/errors v0.8.1 // indirect
 	go.uber.org/atomic v1.6.0 // indirect
 	go.uber.org/multierr v1.5.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,6 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f h1:kDxGY2VmgABOe55qheT/TFqUMtcTHnomIPS1iv3G4Ms=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/infrastructure/http_error_creator.go
+++ b/infrastructure/http_error_creator.go
@@ -1,31 +1,36 @@
 package infrastructure
 
-import Openapi "github.com/nekochans/portfolio-backend/openapi"
+import (
+	"github.com/nekochans/portfolio-backend/domain"
+	Openapi "github.com/nekochans/portfolio-backend/openapi"
+	"github.com/pkg/errors"
+)
 
 type HttpErrorCreator struct{}
 
-func (h *HttpErrorCreator) CreateFromMsg(msg string) Openapi.Error {
+func (c *HttpErrorCreator) CreateFromError(err error) Openapi.Error {
 	const notFoundErrorCode = 404
 	const internalServerErrorCode = 500
 
-	code := internalServerErrorCode
-	message := "Internal Server Error"
+	var code int
+	var message string
 
-	m := map[string]int{
-		"MysqlMemberRepository.Find: Member Not Found":             notFoundErrorCode,
-		"MysqlMemberRepository.FindAll: Members Not Found":         notFoundErrorCode,
-		"MysqlWebServiceRepository.FindAll: WebServices Not Found": notFoundErrorCode,
+	switch errors.Cause(err) {
+	case domain.ErrMemberNotFound:
+		code = notFoundErrorCode
+		message = "Member Not Found"
+	case domain.ErrWebServiceNotFound:
+		code = notFoundErrorCode
+		message = "WebService Not Found"
+	default:
+		code = internalServerErrorCode
+		message = "Internal Server Error"
 	}
 
-	if m[msg] != 0 {
-		code = m[msg]
-		message = msg
-	}
-
-	err := Openapi.Error{
+	resErr := Openapi.Error{
 		Code:    code,
 		Message: message,
 	}
 
-	return err
+	return resErr
 }

--- a/infrastructure/http_response.go
+++ b/infrastructure/http_response.go
@@ -32,9 +32,13 @@ func CreateJsonResponse(w http.ResponseWriter, r *http.Request, status int, payl
 
 func CreateErrorResponse(w http.ResponseWriter, r *http.Request, err error) error {
 	logger := CreateLogger()
-	logger.Error(err.Error(), zap.String("RequestId", middleware.GetReqID(r.Context())))
+	logger.Error(
+		err.Error(),
+		zap.String("RequestId", middleware.GetReqID(r.Context())),
+		zap.Error(err),
+	)
 
 	errCreator := &HttpErrorCreator{}
-	httpError := errCreator.CreateFromMsg(err.Error())
+	httpError := errCreator.CreateFromError(err)
 	return CreateJsonResponse(w, r, httpError.Code, httpError)
 }

--- a/infrastructure/http_server.go
+++ b/infrastructure/http_server.go
@@ -15,8 +15,8 @@ import (
 	Openapi "github.com/nekochans/portfolio-backend/openapi"
 	"github.com/nekochans/portfolio-backend/usecase/memberusecase"
 	"github.com/nekochans/portfolio-backend/usecase/webserviceusecase"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 )
 
 type HttpServer struct {
@@ -35,8 +35,8 @@ func (s *HttpServer) GetMembers(w http.ResponseWriter, r *http.Request) {
 	if ErrFetchAll != nil {
 		ErrCreateError := CreateErrorResponse(w, r, ErrFetchAll)
 		if ErrCreateError != nil {
-			ErrCreateErrorResponse := xerrors.Errorf("Failed to create error response: %w", ErrCreateError)
-			s.Logger.Error(ErrCreateError.Error(), zap.Error(ErrCreateErrorResponse))
+			ErrCreateErrorResponse := errors.Wrap(ErrCreateError, "failed to create error response")
+			s.Logger.Error(ErrCreateErrorResponse.Error(), zap.Error(ErrCreateErrorResponse))
 		}
 
 		return
@@ -44,8 +44,8 @@ func (s *HttpServer) GetMembers(w http.ResponseWriter, r *http.Request) {
 
 	ErrCreateJson := CreateJsonResponse(w, r, http.StatusOK, members)
 	if ErrCreateJson != nil {
-		ErrCreateJsonResponse := xerrors.Errorf("Failed to create json response: %w", ErrCreateJson)
-		s.Logger.Error(ErrCreateJson.Error(), zap.Error(ErrCreateJsonResponse))
+		ErrCreateJsonResponse := errors.Wrap(ErrCreateJson, "failed to create json response")
+		s.Logger.Error(ErrCreateJsonResponse.Error(), zap.Error(ErrCreateJsonResponse))
 	}
 }
 
@@ -58,16 +58,16 @@ func (s *HttpServer) GetMemberById(w http.ResponseWriter, r *http.Request, id in
 	if ErrFetch != nil {
 		ErrCreateError := CreateErrorResponse(w, r, ErrFetch)
 		if ErrCreateError != nil {
-			ErrCreateErrorResponse := xerrors.Errorf("Failed to create error response: %w", ErrCreateError)
-			s.Logger.Error(ErrCreateError.Error(), zap.Error(ErrCreateErrorResponse))
+			ErrCreateErrorResponse := errors.Wrap(ErrCreateError, "failed to create error response")
+			s.Logger.Error(ErrCreateErrorResponse.Error(), zap.Error(ErrCreateErrorResponse))
 		}
 		return
 	}
 
 	ErrCreateJson := CreateJsonResponse(w, r, http.StatusOK, member)
 	if ErrCreateJson != nil {
-		ErrCreateJsonResponse := xerrors.Errorf("Failed to create json response: %w", ErrCreateJson)
-		s.Logger.Error(ErrCreateJson.Error(), zap.Error(ErrCreateJsonResponse))
+		ErrCreateJsonResponse := errors.Wrap(ErrCreateJson, "failed to create json response")
+		s.Logger.Error(ErrCreateJsonResponse.Error(), zap.Error(ErrCreateJsonResponse))
 	}
 }
 
@@ -80,16 +80,16 @@ func (s *HttpServer) GetWebservices(w http.ResponseWriter, r *http.Request) {
 	if ErrFetchAll != nil {
 		ErrCreateError := CreateErrorResponse(w, r, ErrFetchAll)
 		if ErrCreateError != nil {
-			ErrCreateErrorResponse := xerrors.Errorf("Failed to create error response: %w", ErrCreateError)
-			s.Logger.Error(ErrCreateError.Error(), zap.Error(ErrCreateErrorResponse))
+			ErrCreateErrorResponse := errors.Wrap(ErrCreateError, "failed to create error response")
+			s.Logger.Error(ErrCreateErrorResponse.Error(), zap.Error(ErrCreateErrorResponse))
 		}
 		return
 	}
 
 	ErrCreateJson := CreateJsonResponse(w, r, http.StatusOK, res)
 	if ErrCreateJson != nil {
-		ErrCreateJsonResponse := xerrors.Errorf("Failed to create json response: %w", ErrCreateJson)
-		s.Logger.Error(ErrCreateJson.Error(), zap.Error(ErrCreateJsonResponse))
+		ErrCreateJsonResponse := errors.Wrap(ErrCreateJson, "failed to create json response")
+		s.Logger.Error(ErrCreateJsonResponse.Error(), zap.Error(ErrCreateJsonResponse))
 	}
 }
 
@@ -132,15 +132,15 @@ func StartHttpServer() {
 	defer func() {
 		ErrSync := logger.Sync()
 		if ErrSync != nil {
-			ErrLoggerSync := xerrors.Errorf("Failed to logger Sync: %w", ErrSync)
-			logger.Error(ErrSync.Error(), zap.Error(ErrLoggerSync))
+			ErrLoggerSync := errors.Wrap(ErrSync, "failed to logger sync")
+			logger.Error(ErrLoggerSync.Error(), zap.Error(ErrLoggerSync))
 		}
 	}()
 
 	db, ErrConnectDb := sql.Open("mysql", config.GetDsn())
 	if ErrConnectDb != nil {
-		ErrMysqlConnect := xerrors.Errorf("Unable to connect to MySQL server: %w", ErrConnectDb)
-		logger.Error(ErrConnectDb.Error(), zap.Error(ErrMysqlConnect))
+		ErrMysqlConnect := errors.Wrap(ErrConnectDb, "unable to connect to mysql server")
+		logger.Error(ErrMysqlConnect.Error(), zap.Error(ErrMysqlConnect))
 	}
 
 	router := chi.NewRouter()

--- a/infrastructure/logger.go
+++ b/infrastructure/logger.go
@@ -54,7 +54,7 @@ func CreateLogger() *zap.Logger {
 		OutputPaths:      []string{"stdout"},
 		ErrorOutputPaths: []string{"stderr"},
 	}
-	logger, _ := zapConfig.Build()
+	logger, _ := zapConfig.Build(zap.AddCallerSkip(1))
 
 	return logger
 }

--- a/test/seeder.go
+++ b/test/seeder.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/go-sql-driver/mysql"
-	"golang.org/x/xerrors"
+	"github.com/pkg/errors"
 )
 
 type Seeder struct {
@@ -18,12 +18,12 @@ type Seeder struct {
 func (s *Seeder) Execute() error {
 	files, ErrReadDir := ioutil.ReadDir(s.DirPath)
 	if ErrReadDir != nil {
-		return ErrReadDir
+		return errors.Wrap(ErrReadDir, "failed to read dir")
 	}
 
 	tx, ErrTransactionBegin := s.Db.Begin()
 	if ErrTransactionBegin != nil {
-		return ErrTransactionBegin
+		return errors.Wrap(ErrTransactionBegin, "failed to begin transaction")
 	}
 
 	for _, file := range files {
@@ -38,9 +38,9 @@ func (s *Seeder) Execute() error {
 		if _, ErrLoadData := s.loadDataFromCsv(tx, table, csvFilePath); ErrLoadData != nil {
 			ErrRollback := tx.Rollback()
 			if ErrRollback != nil {
-				return xerrors.Errorf("Transaction.Rollback() Fatal: %w", ErrRollback)
+				return errors.Wrap(ErrRollback, "failed to Transaction.Rollback()")
 			}
-			return ErrLoadData
+			return errors.Wrap(ErrLoadData, "failed to loadDataFromCsv")
 		}
 	}
 
@@ -50,16 +50,16 @@ func (s *Seeder) Execute() error {
 func (s *Seeder) TruncateAllTable() error {
 	tx, ErrTransactionBegin := s.Db.Begin()
 	if ErrTransactionBegin != nil {
-		return ErrTransactionBegin
+		return errors.Wrap(ErrTransactionBegin, "failed to s.Db.Begin()")
 	}
 
 	_, ErrSetForeignKeyFalse := tx.Exec("SET FOREIGN_KEY_CHECKS=0")
 	if ErrSetForeignKeyFalse != nil {
 		ErrRollback := tx.Rollback()
 		if ErrRollback != nil {
-			return xerrors.Errorf("Transaction.Rollback() Fatal: %w", ErrRollback)
+			return errors.Wrap(ErrRollback, "failed to Transaction.Rollback()")
 		}
-		return ErrSetForeignKeyFalse
+		return errors.Wrap(ErrSetForeignKeyFalse, "failed to exec sql")
 	}
 
 	// TODO テーブル分ループさせるように改修を行う
@@ -67,36 +67,36 @@ func (s *Seeder) TruncateAllTable() error {
 	if ErrTruncateMembers != nil {
 		ErrRollback := tx.Rollback()
 		if ErrRollback != nil {
-			return xerrors.Errorf("Transaction.Rollback() Fatal: %w", ErrRollback)
+			return errors.Wrap(ErrRollback, "failed to Transaction.Rollback()")
 		}
-		return ErrTruncateMembers
+		return errors.Wrap(ErrTruncateMembers, "failed to exec sql")
 	}
 
 	_, ErrTruncateGitHubUsers := tx.Exec("TRUNCATE members_github_users")
 	if ErrTruncateGitHubUsers != nil {
 		ErrRollback := tx.Rollback()
 		if ErrRollback != nil {
-			return xerrors.Errorf("Transaction.Rollback() Fatal: %w", ErrRollback)
+			return errors.Wrap(ErrRollback, "failed to Transaction.Rollback()")
 		}
-		return ErrTruncateGitHubUsers
+		return errors.Wrap(ErrTruncateGitHubUsers, "failed to exec sql")
 	}
 
 	_, ErrTruncateWebServices := tx.Exec("TRUNCATE webservices")
 	if ErrTruncateWebServices != nil {
 		ErrRollback := tx.Rollback()
 		if ErrRollback != nil {
-			return xerrors.Errorf("Transaction.Rollback() Fatal: %w", ErrRollback)
+			return errors.Wrap(ErrRollback, "failed to Transaction.Rollback()")
 		}
-		return ErrTruncateWebServices
+		return errors.Wrap(ErrTruncateWebServices, "failed to exec sql")
 	}
 
 	_, ErrSetForeignKeyTrue := tx.Exec("SET FOREIGN_KEY_CHECKS=1")
 	if ErrSetForeignKeyTrue != nil {
 		ErrRollback := tx.Rollback()
 		if ErrRollback != nil {
-			return xerrors.Errorf("Transaction.Rollback() Fatal: %w", ErrRollback)
+			return errors.Wrap(ErrRollback, "failed to Transaction.Rollback()")
 		}
-		return ErrSetForeignKeyTrue
+		return errors.Wrap(ErrSetForeignKeyTrue, "failed to exec sql")
 	}
 
 	return tx.Commit()

--- a/test/seeder.go
+++ b/test/seeder.go
@@ -3,7 +3,7 @@ package test
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/go-sql-driver/mysql"
@@ -16,7 +16,7 @@ type Seeder struct {
 }
 
 func (s *Seeder) Execute() error {
-	files, ErrReadDir := ioutil.ReadDir(s.DirPath)
+	files, ErrReadDir := os.ReadDir(s.DirPath)
 	if ErrReadDir != nil {
 		return errors.Wrap(ErrReadDir, "failed to read dir")
 	}

--- a/usecase/memberusecase/usecase_test.go
+++ b/usecase/memberusecase/usecase_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nekochans/portfolio-backend/infrastructure/repository"
 	Openapi "github.com/nekochans/portfolio-backend/openapi"
 	"github.com/nekochans/portfolio-backend/test"
+	"github.com/pkg/errors"
 )
 
 var db *sql.DB
@@ -76,15 +77,17 @@ func TestFetchFromMysqlHandler(t *testing.T) {
 		req := &MemberFetchRequest{Id: 99}
 
 		res, err := u.FetchFromMysql(*req)
-		expected := "MysqlMemberRepository.Find: Member Not Found"
+		expected := domain.ErrMemberNotFound
 
 		if res != nil {
 			t.Error("\nActually: ", res, "\nExpected: ", expected)
 		}
 
+		resErr := errors.Cause(err)
+
 		if err != nil {
-			if err.Error() != expected {
-				t.Error("\nActually: ", err.Error(), "\nExpected: ", expected)
+			if resErr != expected {
+				t.Error("\nActually: ", resErr, "\nExpected: ", expected)
 			}
 		}
 	})
@@ -181,15 +184,17 @@ func TestFetchAllFromMysqlHandler(t *testing.T) {
 		u := &UseCase{MemberRepository: repo}
 
 		res, err := u.FetchAllFromMysql()
-		expected := "MysqlMemberRepository.FindAll: Members Not Found"
+		expected := domain.ErrMemberNotFound
 
 		if res != nil {
 			t.Error("\nActually: ", res, "\nExpected: ", expected)
 		}
 
+		resErr := errors.Cause(err)
+
 		if err != nil {
-			if err.Error() != expected {
-				t.Error("\nActually: ", err.Error(), "\nExpected: ", expected)
+			if resErr != expected {
+				t.Error("\nActually: ", resErr, "\nExpected: ", expected)
 			}
 		}
 	})

--- a/usecase/webserviceusecase/usecase_test.go
+++ b/usecase/webserviceusecase/usecase_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nekochans/portfolio-backend/infrastructure/repository"
 	Openapi "github.com/nekochans/portfolio-backend/openapi"
 	"github.com/nekochans/portfolio-backend/test"
+	"github.com/pkg/errors"
 )
 
 var db *sql.DB
@@ -101,15 +102,16 @@ func TestFetchAllFromMysqlHandler(t *testing.T) {
 		repo := &repository.MysqlWebServiceRepository{Db: db}
 		u := &UseCase{WebServiceRepository: repo}
 		res, err := u.FetchAllFromMysql()
-		expected := "MysqlWebServiceRepository.FindAll: WebServices Not Found"
+		expected := domain.ErrWebServiceNotFound
 
 		if res != nil {
 			t.Error("\nActually: ", res, "\nExpected: ", expected)
 		}
+		resErr := errors.Cause(err)
 
 		if err != nil {
-			if err.Error() != expected {
-				t.Error("\nActually: ", err.Error(), "\nExpected: ", expected)
+			if resErr != expected {
+				t.Error("\nActually: ", resErr, "\nExpected: ", expected)
 			}
 		}
 	})


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/portfolio-backend/issues/65

# Doneの定義
- https://github.com/nekochans/portfolio-backend/issues/65 の完了の定義を満たしている事

# 変更点概要
全てのerrorを返す場面で `github.com/pkg/errors` の `errors.Wrap()` を使うように変更。

（https://zenn.dev/nekoshita/articles/097e00c6d3d1c9 の記事でも紹介されている `pkg/errors.Wrap` を常に利用するパターンを採用した形です）

`golang.org/x/xerrors` は不要になったので削除。

```json
{
	"level": "ERROR",
	"time": "2021-09-21T01:13:46.873Z",
	"caller": "infrastructure/http_server.go:59",
	"message": "sql: no rows in result set: member not found",
	"RequestId": "bc8bf1aef357/YRLusiFFtm-000001",
	"error": "sql: no rows in result set: member not found",
	"errorVerbose": "member not found\ngithub.com/nekochans/portfolio-backend/domain.init\n\t/go/app/domain/member_repository.go:9\nruntime.doInit\n\t/usr/local/go/src/runtime/proc.go:6498\nruntime.doInit\n\t/usr/local/go/src/runtime/proc.go:6475\nruntime.doInit\n\t/usr/local/go/src/runtime/proc.go:6475\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:238\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1581\nsql: no rows in result set\ngithub.com/nekochans/portfolio-backend/infrastructure/repository.(*MysqlMemberRepository).Find\n\t/go/app/infrastructure/repository/mysql_member_repository.go:61\ngithub.com/nekochans/portfolio-backend/usecase/memberusecase.(*UseCase).FetchFromMysql\n\t/go/app/usecase/memberusecase/usecase.go:17\ngithub.com/nekochans/portfolio-backend/infrastructure.(*HttpServer).GetMemberById\n\t/go/app/infrastructure/http_server.go:57\ngithub.com/nekochans/portfolio-backend/openapi.(*ServerInterfaceWrapper).GetMemberById\n\t/go/app/openapi/server.gen.go:54\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi.(*ChainHandler).ServeHTTP\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/chain.go:31\ngithub.com/go-chi/chi.(*Mux).routeHTTP\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/mux.go:425\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi/middleware.Timeout.func1.1\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/middleware/timeout.go:45\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi/middleware.Recoverer.func1\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/middleware/recoverer.go:35\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/nekochans/portfolio-backend/infrastructure.Logger.func1.1\n\t/go/app/infrastructure/logger.go:29\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi/middleware.RequestID.func1\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/middleware/request_id.go:76\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi.(*Mux).ServeHTTP\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/mux.go:82\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2878\nnet/http.(*conn).serve\n\t/usr/local/go/src/net/http/server.go:1929\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1581",
	"stackTrace": "github.com/nekochans/portfolio-backend/infrastructure.(*HttpServer).GetMemberById\n\t/go/app/infrastructure/http_server.go:59\ngithub.com/nekochans/portfolio-backend/openapi.(*ServerInterfaceWrapper).GetMemberById\n\t/go/app/openapi/server.gen.go:54\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi.(*ChainHandler).ServeHTTP\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/chain.go:31\ngithub.com/go-chi/chi.(*Mux).routeHTTP\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/mux.go:425\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi/middleware.Timeout.func1.1\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/middleware/timeout.go:45\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi/middleware.Recoverer.func1\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/middleware/recoverer.go:35\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/nekochans/portfolio-backend/infrastructure.Logger.func1.1\n\t/go/app/infrastructure/logger.go:29\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi/middleware.RequestID.func1\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/middleware/request_id.go:76\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi.(*Mux).ServeHTTP\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/mux.go:82\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2878\nnet/http.(*conn).serve\n\t/usr/local/go/src/net/http/server.go:1929"
}
```

```json
{
	"level": "ERROR",
	"time": "2021-09-21T01:15:54.282Z",
	"caller": "infrastructure/http_server.go:81",
	"message": "record not found in webservices: web service not found",
	"RequestId": "bc8bf1aef357/YRLusiFFtm-000003",
	"error": "record not found in webservices: web service not found",
	"errorVerbose": "web service not found\ngithub.com/nekochans/portfolio-backend/domain.init\n\t/go/app/domain/web_service_repository.go:6\nruntime.doInit\n\t/usr/local/go/src/runtime/proc.go:6498\nruntime.doInit\n\t/usr/local/go/src/runtime/proc.go:6475\nruntime.doInit\n\t/usr/local/go/src/runtime/proc.go:6475\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:238\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1581\nrecord not found in webservices\ngithub.com/nekochans/portfolio-backend/infrastructure/repository.(*MysqlWebServiceRepository).FindAll\n\t/go/app/infrastructure/repository/mysql_web_service_repository.go:74\ngithub.com/nekochans/portfolio-backend/usecase/webserviceusecase.(*UseCase).FetchAllFromMysql\n\t/go/app/usecase/webserviceusecase/usecase.go:32\ngithub.com/nekochans/portfolio-backend/infrastructure.(*HttpServer).GetWebservices\n\t/go/app/infrastructure/http_server.go:79\ngithub.com/nekochans/portfolio-backend/openapi.(*ServerInterfaceWrapper).GetWebservices\n\t/go/app/openapi/server.gen.go:61\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi.(*ChainHandler).ServeHTTP\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/chain.go:31\ngithub.com/go-chi/chi.(*Mux).routeHTTP\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/mux.go:425\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi/middleware.Timeout.func1.1\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/middleware/timeout.go:45\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi/middleware.Recoverer.func1\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/middleware/recoverer.go:35\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/nekochans/portfolio-backend/infrastructure.Logger.func1.1\n\t/go/app/infrastructure/logger.go:29\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi/middleware.RequestID.func1\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/middleware/request_id.go:76\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi.(*Mux).ServeHTTP\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/mux.go:82\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2878\nnet/http.(*conn).serve\n\t/usr/local/go/src/net/http/server.go:1929\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1581",
	"stackTrace": "github.com/nekochans/portfolio-backend/infrastructure.(*HttpServer).GetWebservices\n\t/go/app/infrastructure/http_server.go:81\ngithub.com/nekochans/portfolio-backend/openapi.(*ServerInterfaceWrapper).GetWebservices\n\t/go/app/openapi/server.gen.go:61\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi.(*ChainHandler).ServeHTTP\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/chain.go:31\ngithub.com/go-chi/chi.(*Mux).routeHTTP\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/mux.go:425\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi/middleware.Timeout.func1.1\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/middleware/timeout.go:45\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi/middleware.Recoverer.func1\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/middleware/recoverer.go:35\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/nekochans/portfolio-backend/infrastructure.Logger.func1.1\n\t/go/app/infrastructure/logger.go:29\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi/middleware.RequestID.func1\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/middleware/request_id.go:76\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2046\ngithub.com/go-chi/chi.(*Mux).ServeHTTP\n\t/go/pkg/mod/github.com/go-chi/chi@v4.0.3+incompatible/mux.go:82\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2878\nnet/http.(*conn).serve\n\t/usr/local/go/src/net/http/server.go:1929"
}
```

# 補足情報
本件対応時にLoggerの生成タイミングが複数ある事を発見したので、https://github.com/nekochans/portfolio-backend/issues/62 で改善する。
