### PR TITLE
M1 Macでローカル環境が動作するように対応

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,15 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=covprofile.out -service=github
+  mod:
+    name: go mod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: run go mod tidy
+        run: go mod tidy && git diff -s --exit-code go.sum

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,5 @@ test:
 	@go clean -testcache
 	@go test -p 1 -v ./...
 ci: lint
-	@go mod tidy && git diff -s --exit-code go.sum
 	@go clean -testcache
 	@go test -p 1 -v -coverprofile=covprofile.out -covermode atomic ./...

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.0.23
+FROM --platform=linux/x86_64 mysql:8.0.23
 
 LABEL maintainer="https://github.com/nekochans"
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/portfolio-backend/issues/87

# 関連URL
なし

# Doneの定義
- M1 MacでDockerを利用したローカル環境が構築出来る状態になっている事

# スクリーンショット
なし

# 変更点概要
M1 MacでMySQLのコンテナを立ち上げる為に `docker/mysql/Dockerfile` の `from` に `--platform=linux/x86_64` を追記しました。

またCIが動作しなくなっていたのでこちらも対応しています。

CIの失敗原因ですが以前はコンテナの中で行っていた `go mod tidy && git diff -s --exit-code go.sum` （go mod tidyが実行済で `go.sum` がコミットされている事を確認する為のスクリプト）がコンテナ内で動作しなくなった為、`.github/workflows/ci.yml` で `mod` として独立させる形を取りました。

今後はtestやlintなども分離していければと思っています。

# レビュアーに重点的にチェックして欲しい点
特になし

# 補足情報
特になし